### PR TITLE
feat(share): add /share slash command for shareable session links

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build": "tsup",
     "build:remote": "npm run build:remote-agent",
     "build:remote-agent": "cd remote/agent && npx tsup",
+    "deploy:share-worker": "cd share-worker && npm install && wrangler deploy",
     "dev": "tsx src/index.tsx",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts src/**/*.test.tsx",

--- a/share-worker/README.md
+++ b/share-worker/README.md
@@ -1,0 +1,30 @@
+# KimiFlare Share Worker
+
+Cloudflare Worker that hosts shared KimiFlare sessions.
+
+## Deploy
+
+```bash
+npm run deploy:share-worker
+```
+
+Then set the auth secret:
+
+```bash
+cd share-worker && wrangler secret put SHARE_AUTH_SECRET
+```
+
+## Configure KimiFlare
+
+Add to `~/.config/kimiflare/config.json`:
+
+```json
+{
+  "shareWorkerUrl": "https://kimiflare-share.<your-subdomain>.workers.dev",
+  "shareAuthSecret": "<the-secret-you-set-above>"
+}
+```
+
+## Usage
+
+In a KimiFlare session, type `/share` to get a public link.

--- a/share-worker/package.json
+++ b/share-worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kimiflare-share-worker",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "hono": "^4.7.0"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/share-worker/src/index.ts
+++ b/share-worker/src/index.ts
@@ -1,0 +1,140 @@
+import { Hono } from "hono";
+import { VIEWER_HTML } from "./viewer-html.js";
+
+export interface Env {
+  SHARE_BUCKET: R2Bucket;
+  SHARE_AUTH_SECRET: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+app.use("*", async (c, next) => {
+  if (c.req.method === "OPTIONS") {
+    return new Response(null, { headers: CORS_HEADERS });
+  }
+  await next();
+  // Attach CORS to all responses
+  const res = c.res;
+  if (res) {
+    for (const [k, v] of Object.entries(CORS_HEADERS)) {
+      res.headers.set(k, v);
+    }
+  }
+});
+
+function makeId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+// Health / landing
+app.get("/", (c) => {
+  return c.html(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>KimiFlare Share</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;text-align:center}
+.container{max-width:480px;padding:24px}
+h1{margin:0 0 8px;font-size:24px}
+p{color:#8b949e;margin:0 0 16px}
+a{color:#58a6ff;text-decoration:none}
+</style></head>
+<body><div class="container"><h1>KimiFlare Share</h1>
+<p>Session sharing is enabled.</p>
+<p><a href="https://github.com/sinameraji/kimiflare">github.com/sinameraji/kimiflare</a></p>
+</div></body></html>`);
+});
+
+// Upload endpoint
+app.post("/api/upload", async (c) => {
+  const auth = c.req.header("Authorization") ?? "";
+  const expected = `Bearer ${c.env.SHARE_AUTH_SECRET}`;
+  if (!crypto.subtle) {
+    // Fallback for environments without subtle
+    if (auth !== expected) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+  } else {
+    const enc = new TextEncoder();
+    const a = enc.encode(auth);
+    const b = enc.encode(expected);
+    if (a.byteLength !== b.byteLength) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const same = await crypto.subtle.timingSafeEqual(a, b);
+    if (!same) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+  }
+
+  const body = await c.req.text();
+  if (!body || body.length > 50 * 1024 * 1024) {
+    return c.json({ error: "Body too large or empty" }, 400);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+
+  // Basic validation: must be an object with messages array
+  if (!parsed || typeof parsed !== "object" || !Array.isArray((parsed as Record<string, unknown>).messages)) {
+    return c.json({ error: "Invalid session format" }, 400);
+  }
+
+  const id = makeId();
+  const key = `shares/${id}.json`;
+  await c.env.SHARE_BUCKET.put(key, body, {
+    httpMetadata: { contentType: "application/json" },
+  });
+
+  const url = new URL(c.req.url);
+  const shareUrl = `${url.protocol}//${url.host}/s/${id}`;
+  return c.json({ id, url: shareUrl });
+});
+
+// Serve session JSON
+app.get("/api/session/:id", async (c) => {
+  const id = c.req.param("id");
+  if (!/^[a-zA-Z0-9]+$/.test(id)) {
+    return c.json({ error: "Invalid ID" }, 400);
+  }
+  const obj = await c.env.SHARE_BUCKET.get(`shares/${id}.json`);
+  if (!obj) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  const body = await obj.text();
+  return new Response(body, {
+    headers: { "Content-Type": "application/json" },
+  });
+});
+
+// Viewer page
+app.get("/s/:id", async (c) => {
+  const id = c.req.param("id");
+  if (!/^[a-zA-Z0-9]+$/.test(id)) {
+    return c.text("Invalid ID", 400);
+  }
+  // Verify the object exists before serving the viewer
+  const obj = await c.env.SHARE_BUCKET.head(`shares/${id}.json`);
+  if (!obj) {
+    return c.html(`<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>Not Found</title>
+<style>body{font-family:sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
+</head><body><div>Session not found.</div></body></html>`, 404);
+  }
+  const html = VIEWER_HTML.replace(
+    '<main id="main"><div class="loading">Loading session…</div></main>',
+    `<main id="main"><div class="loading">Loading session…</div></main><script>window.__SESSION_ID__=${JSON.stringify(id)};</script>`
+  );
+  return c.html(html);
+});
+
+export default app;

--- a/share-worker/src/viewer-html.ts
+++ b/share-worker/src/viewer-html.ts
@@ -1,0 +1,152 @@
+export const VIEWER_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KimiFlare Session</title>
+<style>
+:root{--bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#c9d1d9;--muted:#8b949e;--user:#58a6ff;--asst:#3fb950;--tool:#d29922;--sys:#8b949e;--err:#f85149;}
+*{box-sizing:border-box}
+body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
+header{position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);padding:12px 16px;display:flex;align-items:center;gap:12px;z-index:10}
+header h1{margin:0;font-size:16px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+header .meta{color:var(--muted);font-size:12px;margin-left:auto;white-space:nowrap}
+header button{background:var(--border);color:var(--text);border:none;padding:6px 12px;border-radius:6px;cursor:pointer;font-size:12px}
+header button:hover{background:#30363d}
+main{max-width:900px;margin:0 auto;padding:16px}
+.msg{margin-bottom:16px;border:1px solid var(--border);border-radius:8px;background:var(--surface);overflow:hidden}
+.msg-header{padding:8px 12px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;display:flex;align-items:center;gap:8px}
+.msg-user .msg-header{color:var(--user);background:rgba(88,166,255,.08)}
+.msg-asst .msg-header{color:var(--asst);background:rgba(63,185,80,.08)}
+.msg-tool .msg-header{color:var(--tool);background:rgba(210,153,34,.08);cursor:pointer}
+.msg-sys .msg-header{color:var(--sys);background:rgba(139,148,158,.08)}
+.msg-body{padding:12px;white-space:pre-wrap;word-break:break-word;font-size:14px}
+.msg-body code{font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;background:rgba(255,255,255,.06);padding:2px 4px;border-radius:4px;font-size:13px}
+.msg-body pre{background:rgba(0,0,0,.2);padding:12px;border-radius:6px;overflow-x:auto}
+.msg-body pre code{background:none;padding:0}
+.tool-details{display:none;padding:12px;border-top:1px solid var(--border);background:rgba(0,0,0,.15);font-size:13px}
+.tool-details.open{display:block}
+.tool-details pre{margin:0;white-space:pre-wrap;word-break:break-word}
+.error{color:var(--err);padding:16px;text-align:center}
+.loading{color:var(--muted);padding:40px;text-align:center}
+.empty{color:var(--muted);padding:40px;text-align:center}
+footer{text-align:center;color:var(--muted);font-size:12px;padding:24px}
+</style>
+</head>
+<body>
+<header>
+<h1 id="title">KimiFlare Session</h1>
+<span class="meta" id="meta"></span>
+<button id="copyBtn">Copy transcript</button>
+</header>
+<main id="main"><div class="loading">Loading session…</div></main>
+<footer>Shared via <a href="https://github.com/sinameraji/kimiflare" style="color:var(--muted)">KimiFlare</a></footer>
+<script>
+const params=new URLSearchParams(location.search);
+const sessionId=params.get('session');
+const fileUrl=params.get('file');
+
+async function loadSession(){
+  let url;
+  if(sessionId) url='./api/session/'+encodeURIComponent(sessionId);
+  else if(fileUrl) url=fileUrl;
+  else{renderError('No session ID or file URL provided.');return}
+  const res=await fetch(url);
+  if(!res.ok){renderError('Failed to load session: '+res.status);return}
+  const data=await res.json();
+  render(data);
+}
+
+function escapeHtml(s){return s.replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+
+function mdToHtml(text){
+  return escapeHtml(text)
+    .replace(/\`\`\`([\s\S]*?)\`\`\`/g,'<pre><code>$1</code></pre>')
+    .replace(/\`([^\`]+)\`/g,'<code>$1</code>')
+    .replace(/\*\*([^\*]+)\*\*/g,'<strong>$1</strong>')
+    .replace(/\*([^\*]+)\*/g,'<em>$1</em>')
+    .replace(/\n/g,'<br>');
+}
+
+function render(session){
+  const title=session.title||'Untitled Session';
+  document.getElementById('title').textContent=title;
+  const model=session.model||'unknown';
+  const date=session.createdAt?new Date(session.createdAt).toLocaleString():'';
+  const count=(session.messages||[]).filter(m=>m.role!=='system').length;
+  document.getElementById('meta').textContent=\`\${model} · \${count} messages · \${date}\`;
+
+  const main=document.getElementById('main');
+  main.innerHTML='';
+  const msgs=session.messages||[];
+  if(!msgs.length){main.innerHTML='<div class="empty">No messages in this session.</div>';return}
+
+  for(const m of msgs){
+    if(m.role==='system') continue;
+    const div=document.createElement('div');
+    div.className='msg msg-'+m.role;
+    const header=document.createElement('div');
+    header.className='msg-header';
+    const label=m.role==='user'?'You':m.role==='assistant'?'Kimi':m.role==='tool'?'Tool':'System';
+    header.textContent=label;
+    div.appendChild(header);
+
+    if(m.role==='tool'||m.tool_calls){
+      const body=document.createElement('div');
+      body.className='msg-body';
+      if(m.tool_calls){
+        for(const tc of m.tool_calls){
+          const name=tc.function?.name||tc.name||'tool';
+          const args=tc.function?.arguments||tc.arguments||'{}';
+          body.innerHTML+='<div><strong>'+escapeHtml(name)+'</strong>('+escapeHtml(args)+')</div>';
+        }
+      }else{
+        body.textContent=typeof m.content==='string'?m.content:JSON.stringify(m.content);
+      }
+      div.appendChild(body);
+
+      if(m.role==='tool'&&m.content){
+        const details=document.createElement('div');
+        details.className='tool-details';
+        const pre=document.createElement('pre');
+        pre.textContent=typeof m.content==='string'?m.content:JSON.stringify(m.content,null,2);
+        details.appendChild(pre);
+        div.appendChild(details);
+        header.addEventListener('click',()=>details.classList.toggle('open'));
+        header.innerHTML+=' <span style="font-size:10px;opacity:.7">(click to expand)</span>';
+      }
+    }else{
+      const body=document.createElement('div');
+      body.className='msg-body';
+      const text=typeof m.content==='string'?m.content:(m.content||[]).map(p=>p.type==='text'?p.text:'').join('');
+      body.innerHTML=mdToHtml(text);
+      div.appendChild(body);
+    }
+    main.appendChild(div);
+  }
+
+  document.getElementById('copyBtn').addEventListener('click',()=>{
+    const lines=[];
+    for(const m of msgs){
+      if(m.role==='system') continue;
+      const label=m.role==='user'?'You':m.role==='assistant'?'Kimi':m.role==='tool'?'Tool':'System';
+      const text=typeof m.content==='string'?m.content:(m.content||[]).map(p=>p.type==='text'?p.text:'').join('');
+      lines.push(label+':\\n'+text);
+    }
+    navigator.clipboard.writeText(lines.join('\\n\\n')).then(()=>{
+      const btn=document.getElementById('copyBtn');
+      const old=btn.textContent;
+      btn.textContent='Copied!';
+      setTimeout(()=>btn.textContent=old,1500);
+    });
+  });
+}
+
+function renderError(msg){
+  document.getElementById('main').innerHTML='<div class="error">'+escapeHtml(msg)+'</div>';
+}
+
+loadSession().catch(e=>renderError(e.message));
+</script>
+</body>
+</html>`;

--- a/share-worker/tsconfig.json
+++ b/share-worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/share-worker/wrangler.toml
+++ b/share-worker/wrangler.toml
@@ -1,0 +1,17 @@
+name = "kimiflare-share"
+main = "src/index.ts"
+compatibility_date = "2025-04-01"
+
+[[r2_buckets]]
+bucket_name = "kimiflare-shares"
+binding = "SHARE_BUCKET"
+
+# Set SHARE_AUTH_SECRET via `wrangler secret put SHARE_AUTH_SECRET` — do not commit the value.
+# This secret protects the /api/upload endpoint.
+
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+invocation_logs = true

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -169,6 +169,8 @@ export interface Cfg {
   theme?: string;
   remoteWorkerUrl?: string;
   remoteAuthSecret?: string;
+  shareWorkerUrl?: string;
+  shareAuthSecret?: string;
   remoteTtlMinutes?: number;
   remoteMaxInputTokens?: number;
   githubOAuthToken?: string;

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -32,6 +32,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "fresh", description: "Reset session and start fresh with the last plan", source: "builtin" },
   { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
   { name: "remote", argHint: "<prompt>", description: "Run a remote session on Cloudflare", source: "builtin" },
+  { name: "share", description: "Share current session as a web link", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },
   { name: "hello", description: "Send a voice note to the creator", source: "builtin" },
   { name: "report", argHint: "[send] [note]", description: "Report the last API error with diagnostic logs", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,10 @@ export interface KimiConfig {
   remoteWorkerUrl?: string;
   /** Shared secret for authenticating with the remote Worker. */
   remoteAuthSecret?: string;
+  /** URL of the share Worker (for /share link generation). */
+  shareWorkerUrl?: string;
+  /** Shared secret for authenticating with the share Worker. */
+  shareAuthSecret?: string;
   /** Configurable TTL for remote sessions in minutes (default: 30). */
   remoteTtlMinutes?: number;
   /** Max input token budget per remote job (default: 5_000_000). */

--- a/src/share/upload.test.ts
+++ b/src/share/upload.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { uploadSession } from "./upload.js";
+
+describe("uploadSession", () => {
+  it("throws on non-ok response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("bad request", { status: 400 }) as unknown as Response;
+
+    try {
+      await assert.rejects(
+        uploadSession("https://example.com", "secret", "{}"),
+        /Share upload failed \(400\)/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns id and url on success", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ id: "abc123", url: "https://example.com/s/abc123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as unknown as Response;
+
+    try {
+      const result = await uploadSession("https://example.com", "secret", "{}");
+      assert.strictEqual(result.id, "abc123");
+      assert.strictEqual(result.url, "https://example.com/s/abc123");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/share/upload.ts
+++ b/src/share/upload.ts
@@ -1,0 +1,26 @@
+/**
+ * Upload a session JSON to the share Worker and return the public URL.
+ */
+export async function uploadSession(
+  workerUrl: string,
+  authSecret: string,
+  sessionJson: string,
+): Promise<{ id: string; url: string }> {
+  const url = workerUrl.replace(/\/$/, "");
+  const res = await fetch(`${url}/api/upload`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authSecret}`,
+    },
+    body: sessionJson,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new Error(`Share upload failed (${res.status}): ${text}`);
+  }
+
+  const data = (await res.json()) as { id: string; url: string };
+  return data;
+}

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -9,7 +9,7 @@
  */
 import React from "react";
 import { join } from "node:path";
-import { unlink } from "node:fs/promises";
+import { unlink, writeFile } from "node:fs/promises";
 import QRCode from "qrcode";
 
 import type { Cfg } from "../app.js";
@@ -78,6 +78,7 @@ import { deployForTui } from "../remote/deploy.js";
 import { authGitHubForTui } from "../remote/tui-auth.js";
 import { distillSessionPlan } from "../agent/distill.js";
 import { writeToClipboard } from "../util/clipboard.js";
+import { uploadSession } from "../share/upload.js";
 
 type SetEvents = React.Dispatch<React.SetStateAction<ChatEvent[]>>;
 
@@ -1593,6 +1594,92 @@ const handleRemote: Handler = (ctx, rest, arg) => {
   return true;
 };
 
+const handleShare: Handler = (ctx) => {
+  const { cfg, setEvents, mkKey, sessionIdRef, messagesRef, sessionStateRef, artifactStoreRef, compiledContextRef } = ctx;
+
+  const messages = messagesRef.current;
+  if (!messages || messages.length <= 1) {
+    setEvents((e) => [
+      ...e,
+      { kind: "error", key: mkKey(), text: "Nothing to share — start a conversation first." },
+    ]);
+    return true;
+  }
+
+  const sessionId = sessionIdRef.current ?? `session-${Date.now()}`;
+  const now = new Date().toISOString();
+  const firstUser = messages.find((m) => m.role === "user");
+  const title =
+    typeof firstUser?.content === "string"
+      ? firstUser.content.slice(0, 60)
+      : (firstUser?.content ?? []).find((p) => p.type === "text")?.text?.slice(0, 60) ?? "Untitled";
+
+  const sessionFile = {
+    id: sessionId,
+    cwd: process.cwd(),
+    model: cfg?.model ?? "unknown",
+    createdAt: now,
+    updatedAt: now,
+    title,
+    messages,
+    sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
+    artifactStore: serializeArtifactStore(artifactStoreRef.current),
+  };
+
+  const sessionJson = JSON.stringify(sessionFile, null, 2);
+
+  if (cfg?.shareWorkerUrl && cfg?.shareAuthSecret) {
+    (async () => {
+      try {
+        const result = await uploadSession(cfg.shareWorkerUrl!, cfg.shareAuthSecret!, sessionJson);
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `Shared! ${result.url}\nAnyone with the link can view this session.`,
+          },
+        ]);
+      } catch (err) {
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "error",
+            key: mkKey(),
+            text: `Share failed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ]);
+      }
+    })();
+  } else {
+    const fileName = `kimi-session-${now.replace(/[:.]/g, "-")}.json`;
+    (async () => {
+      try {
+        await writeFile(fileName, sessionJson, "utf8");
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `Session saved locally: ${fileName}\nSet shareWorkerUrl + shareAuthSecret in config to enable link sharing.`,
+          },
+        ]);
+      } catch (err) {
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "error",
+            key: mkKey(),
+            text: `Failed to save session: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ]);
+      }
+    })();
+  }
+
+  return true;
+};
+
 const handleHelp: Handler = (ctx) => {
   ctx.setShowHelpMenu(true);
   return true;
@@ -1631,6 +1718,7 @@ const handlers: Record<string, Handler> = {
   "/logout": handleLogout,
   "/command": handleCommand,
   "/remote": handleRemote,
+  "/share": handleShare,
   "/help": handleHelp,
 };
 


### PR DESCRIPTION
Implements Phase 2+3 of #498.

## What's new

- **share-worker/** — New Cloudflare Worker sub-project that hosts shared sessions in R2 and serves a vanilla-JS web viewer.
- **/share slash command** — Uploads the current session and returns a public link. Falls back to writing a local `.json` file if the worker isn't configured.
- **Config fields** — `shareWorkerUrl` and `shareAuthSecret` added to config.
- **Deploy script** — `npm run deploy:share-worker` for one-command deployment.

## Usage

1. Deploy: `npm run deploy:share-worker` then `wrangler secret put SHARE_AUTH_SECRET`
2. Add `shareWorkerUrl` + `shareAuthSecret` to `~/.config/kimiflare/config.json`
3. Type `/share` in any session

Closes #498

Co-authored-by: kimiflare <kimiflare@proton.me>