### PR TITLE
feat(models): add GLM 5.2 (Zhipu AI on Workers AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ KimiFlare runs on **Kimi K2.7** via Cloudflare Workers AI — no API key needed 
 
 - `@cf/moonshotai/kimi-k2.7-code` — 262k context, reasoning, tools, vision
 
-`@cf/moonshotai/kimi-k2.6` and `@cf/moonshotai/kimi-k2.5` are also available.
+`@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.5`, and `@cf/zai-org/glm-5.2`
+(Zhipu AI, 262k context, reasoning + tools) are also available.
 
 ### One-shot mode
 

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -122,6 +122,16 @@ const SEED: ModelEntry[] = [
     supports: { tools: true, reasoning: true, streaming: true },
     billingMode: "unified",
   },
+  // ── GLM (Zhipu AI on Cloudflare Workers AI) ───────────────────────────────
+  {
+    id: "@cf/zai-org/glm-5.2",
+    provider: "workers-ai",
+    contextWindow: 262_144,
+    maxOutputTokens: 16_384,
+    pricing: { inputPerMtok: 1.4, cachedInputPerMtok: 0.26, outputPerMtok: 4.4 },
+    supports: { tools: true, reasoning: true, streaming: true },
+    billingMode: "unified",
+  },
 ];
 
 const seedIndex = new Map<string, ModelEntry>(SEED.map((m) => [m.id, m]));


### PR DESCRIPTION
## What

Adds **GLM 5.2** (`@cf/zai-org/glm-5.2`, Zhipu AI) to the kimiflare model registry so it's selectable via `/model` and `-m`.

GLM 5.2 [shipped on Cloudflare Workers AI on 2026-06-16](https://developers.cloudflare.com/changelog/post/2026-06-16-glm-52-workers-ai/). Because it's a Workers AI (`@cf/…`) model, it reuses the existing dual-path routing — direct via `api.cloudflare.com/.../ai/run/{model}` **or** through AI Gateway when `aiGatewayId` is configured. No routing, provider, or billing plumbing required; the model picker and pricing read from the registry automatically.

## Pricing — from CF docs, matched to the model

Source: [model page](https://developers.cloudflare.com/workers-ai/models/glm-5.2/).

| Field | Value |
|---|---|
| Input | $1.40 / M tokens |
| Cached input | $0.26 / M tokens |
| Output | $4.40 / M tokens |
| Context window | 262,144 (Workers AI launch cap) |
| Capabilities | tools ✅, reasoning ✅, streaming ✅, vision ❌ |

`maxOutputTokens` mirrors the sibling Kimi entries (`16_384`) since CF doesn't publish an output cap. `DEFAULT_MODEL` is unchanged — Kimi K2.7 stays default; GLM is just added to the list.

## Verification

- `npm run build` passes (ESM + DTS type check).
- Runtime lookup confirms `getModel("@cf/zai-org/glm-5.2")` resolves with in `1.4` / cached `0.26` / out `4.4`, `workers-ai` / `unified`.

## Test plan (local)

- `kimiflare`, open `/model` → GLM 5.2 appears and is selectable.
- `kimiflare -m @cf/zai-org/glm-5.2 -p "say hi"` → direct Workers AI path accepts the slug; `/cost` attributes spend at the GLM rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)