### PR TITLE
fix(ui): auto-start execution after plan-complete picker chooses auto/edit

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1528,7 +1528,7 @@ function App({
         return;
       }
 
-      const clipResult = executeFreshStart(buildSlashContext(), plan, picked);
+      const clipResult = executeFreshStart(buildSlashContext(), plan, picked, { seedMessages: false });
 
       setEvents((e) => [
         ...e,

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -1384,9 +1384,12 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
             currentMode,
             ALL_TOOLS,
           );
-          // Seed with plan
-          messages.push({ role: "user", content: plan });
+          // Seed with plan. In Camouflage we queue it as a follow-up so the
+          // main loop immediately starts the next turn in the new mode; just
+          // pushing to `messages` would leave the renderer idle waiting for
+          // the user to type another prompt.
           cam.send("UserMessageCreated", { text: plan });
+          followUpQueue.push(plan);
           cam.send("ShowToast", {
             text: `Starting fresh session in ${targetMode} mode with plan`,
             kind: "success",

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -229,7 +229,12 @@ const handleClear: Handler = (ctx) => {
   return true;
 };
 
-export function executeFreshStart(ctx: SlashContext, planText: string, overrideMode?: Mode): { success: boolean } {
+export function executeFreshStart(
+  ctx: SlashContext,
+  planText: string,
+  overrideMode?: Mode,
+  opts: { seedMessages?: boolean } = {},
+): { success: boolean } {
   // Capture old session ID before reset so we can carry its cost forward
   const oldSessionId = ctx.sessionIdRef.current;
 
@@ -271,8 +276,11 @@ export function executeFreshStart(ctx: SlashContext, planText: string, overrideM
     [...ALL_TOOLS, ...ctx.mcpToolsRef.current, ...ctx.lspToolsRef.current],
   );
 
-  // Seed with plan
-  ctx.messagesRef.current.push({ role: "user", content: planText });
+  // Seed with plan unless the caller will submit it separately (e.g. the
+  // Ink plan-complete picker already calls submitRef.current(plan)).
+  if (opts.seedMessages !== false) {
+    ctx.messagesRef.current.push({ role: "user", content: planText });
+  }
 
   // Force creation of the new session ID and carry over the old cost baseline
   const newSessionId = ctx.ensureSessionId() as string;


### PR DESCRIPTION
Fixes the plan-complete picker so selecting auto/edit actually starts executing instead of stopping for a second confirmation.\n\nSee commit message for details.