### PR TITLE
temporarily disable Camouflage UI access and force Ink

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,7 +44,7 @@ import { join } from "node:path";
 import QRCode from "qrcode";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
-import { checkForUpdate, checkOptionalDependency } from "./util/update-check.js";
+import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { Onboarding } from "./ui/onboarding.js";
 import { Welcome } from "./ui/welcome.js";
@@ -688,26 +688,8 @@ function App({
         ]);
       }
     });
-    void checkOptionalDependency("camouflage-tui", "beta").then((dep) => {
-      if (dep.hasUpdate && dep.latestVersion) {
-        setEvents((e) => [
-          ...e,
-          {
-            kind: "info",
-            key: mkKey(),
-            text: `camouflage-tui update available: ${dep.localVersion} → ${dep.latestVersion}`,
-          },
-        ]);
-        setEvents((e) => [
-          ...e,
-          {
-            kind: "info",
-            key: mkKey(),
-            text: "run:  npm update camouflage-tui",
-          },
-        ]);
-      }
-    });
+    // Camouflage UI access is temporarily disabled; skip camouflage-tui update checks.
+    // void checkOptionalDependency("camouflage-tui", "beta").then((dep) => { ... });
   }, [cfg, initialUpdateResult]);
 
   useEffect(() => {
@@ -770,26 +752,8 @@ function App({
           }
         }
       });
-      void checkOptionalDependency("camouflage-tui", "beta").then((dep) => {
-        if (dep.hasUpdate && dep.latestVersion) {
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: `camouflage-tui update available: ${dep.localVersion} → ${dep.latestVersion}`,
-            },
-          ]);
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: "run:  npm update camouflage-tui",
-            },
-          ]);
-        }
-      });
+      // Camouflage UI access is temporarily disabled; skip camouflage-tui update checks.
+      // void checkOptionalDependency("camouflage-tui", "beta").then((dep) => { ... });
     }, 30 * 60 * 1000); // 30 minutes
     return () => clearInterval(id);
   }, [cfg]);
@@ -1226,24 +1190,9 @@ function App({
   );
 
   const handleUiPick = useCallback(
-    (picked: "ink" | "camouflage" | null) => {
+    (picked: "ink" | null) => {
       setShowUiPicker(false);
       if (!picked) return;
-      if (picked === "camouflage") {
-        // Camouflage is strictly opt-in via CLI flag or env var; we do not
-        // persist it to config so it can never become the silent default.
-        setEvents((e) => [
-          ...e,
-          {
-            kind: "error",
-            key: mkKey(),
-            text:
-              "Camouflage is experimental and must be opted into explicitly. " +
-              "Launch with `kimiflare --ui camouflage` or set `KIMIFLARE_UI=camouflage`.",
-          },
-        ]);
-        return;
-      }
       setCfg((c) => {
         if (!c) return c;
         const updated = { ...c, uiEngine: picked };
@@ -1253,9 +1202,9 @@ function App({
       setEvents((e) => [
         ...e,
         {
-          kind: "error",
+          kind: "info",
           key: mkKey(),
-          text: `UI engine set to "${picked}". RESTART kimiflare for it to take effect.`,
+          text: `UI engine set to "${picked}". React Ink is the only available engine.`,
         },
       ]);
     },
@@ -1429,7 +1378,6 @@ function App({
     setHasUpdate,
     setLatestVersion,
     setShowThemePicker,
-    setShowUiPicker,
     setShowModelPicker,
     setShowModePicker,
     setKeyEntryFor,
@@ -2574,7 +2522,7 @@ function App({
         onLspSave={handleLspSave}
         themes={themeList()}
         onPickTheme={handleThemePick}
-        currentUiEngine={cfg?.uiEngine ?? "ink"}
+        currentUiEngine={cfg?.uiEngine === "ink" ? "ink" : "ink"}
         onPickUi={handleUiPick}
         currentModel={cfg?.model ?? ""}
         onPickModel={handleModelPick}

--- a/src/camouflage-resume.ts
+++ b/src/camouflage-resume.ts
@@ -1,98 +1,15 @@
 /**
- * `kimiflare resume` — first real-world driver of Camouflage's SelectList
- * primitive (CC-1). Lists recent sessions in the current cwd and renders
- * them via Camouflage's SelectList overlay. Prints the chosen session id
- * to stdout. Actual resume semantics (loading the chosen session into a
- * new agent run) is intentionally not wired here — that's KimiFlare-
- * specific and will land in a follow-up. This subcommand validates the
- * round-trip end-to-end against real session data.
+ * `kimiflare resume` is temporarily unavailable while Camouflage UI access is
+ * disabled. This module is kept so imports do not break, but it exits
+ * immediately with an explanatory message.
  */
-
-import { listSessions, type SessionSummary } from "./sessions.js";
 
 export interface CamouflageResumeOpts {
   limit?: number;
   camouflageBin?: string;
 }
 
-export async function runCamouflageResume(opts: CamouflageResumeOpts = {}): Promise<void> {
-  let camMod: typeof import("camouflage-tui");
-  try {
-    camMod = await import("camouflage-tui");
-  } catch {
-    process.stderr.write(
-      "kimiflare resume: the 'camouflage-tui' package is required.\n" +
-        "Install it with: npm install -g camouflage-tui\n",
-    );
-    process.exitCode = 2;
-    return;
-  }
-  const { mount, selectList } = camMod;
-
-  const sessions = await listSessions(opts.limit ?? 20, process.cwd());
-
-  if (sessions.length === 0) {
-    process.stderr.write("kimiflare resume: no saved sessions for this cwd.\n");
-    process.exitCode = 0;
-    return;
-  }
-
-  let cam;
-  try {
-    cam = await mount({
-      bin: opts.camouflageBin,
-      renderToTerminal: true,
-    });
-  } catch (err) {
-    process.stderr.write(
-      `kimiflare resume: failed to launch Camouflage renderer.\n${err instanceof Error ? err.message : err}\n`,
-    );
-    process.exitCode = 2;
-    return;
-  }
-
-  // Seed a minimal session so the picker isn't floating on an empty
-  // transcript. Skip the StatusUpdate cosmetics — the SelectList is the
-  // entire UI here.
-  cam.send("SessionStarted", {});
-
-  const resp = await selectList(cam, {
-    id: "resume-picker",
-    prompt: `Resume which session? (${sessions.length} found in ${process.cwd()})`,
-    options: sessions.map((s: SessionSummary) => ({
-      value: s.id,
-      label: optionLabel(s),
-      description: `${s.messageCount} msgs · ${s.id.slice(0, 8)}`,
-    })),
-    allow_filter: true,
-    allow_cancel: true,
-  });
-
-  cam.send("SessionEnded", {});
-  await cam.close().catch(() => {});
-
-  // Final output goes to stdout so it can be captured / piped.
-  if (resp.cancelled) {
-    process.stdout.write("cancelled\n");
-    process.exitCode = 1;
-  } else {
-    process.stdout.write(`${resp.value}\n`);
-  }
-}
-
-function optionLabel(s: SessionSummary): string {
-  const when = formatRelative(s.updatedAt);
-  const title = (s.title ?? s.firstPrompt ?? "(no title)").trim().replace(/\s+/g, " ");
-  const truncated = title.length > 80 ? `${title.slice(0, 77)}…` : title;
-  return `${when}  ${truncated}`;
-}
-
-function formatRelative(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return iso;
-  const diffMin = (Date.now() - t) / 60_000;
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${Math.round(diffMin)}m ago`;
-  if (diffMin < 60 * 24) return `${Math.round(diffMin / 60)}h ago`;
-  return `${Math.round(diffMin / (60 * 24))}d ago`;
+export async function runCamouflageResume(_opts: CamouflageResumeOpts = {}): Promise<void> {
+  process.stderr.write("kimiflare resume: temporarily unavailable. Camouflage UI access is disabled.\n");
+  process.exitCode = 2;
 }

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -11,7 +11,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "mode", argHint: "edit|plan|auto|multi-agent-experimental", description: "Switch agent mode", source: "builtin" },
   { name: "multi-agent", argHint: "[enable|disable|status|setup]", description: "Configure multi-agent (endpoint, auto-implement, set up)", source: "builtin" },
   { name: "theme", argHint: "[<name>]", description: "Switch color theme", source: "builtin" },
-  { name: "ui", argHint: "ink", description: "Switch UI engine to React Ink (takes effect on next launch). Camouflage is opt-in via --ui camouflage.", source: "builtin" },
+  { name: "ui", argHint: "ink", description: "Switch UI engine to React Ink (takes effect on next launch). Camouflage is temporarily unavailable.", source: "builtin" },
   { name: "plan", description: "Switch to plan mode", source: "builtin" },
   { name: "auto", description: "Switch to auto mode", source: "builtin" },
   { name: "edit", description: "Switch to edit mode", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,11 +97,9 @@ export interface KimiConfig {
   /** Shell override for the bash tool. "auto" (default) detects the platform, or specify "bash", "cmd", "powershell", or an absolute path. */
   shell?: string;
   /**
-   * Preferred interactive UI engine. `"ink"` is the default (stable React/Ink
-   * UI); `"camouflage"` is the experimental Rust TUI. The runtime resolution
-   * chain is: `--ui` flag → `KIMIFLARE_UI` env var → this field → `"ink"`.
-   * Settable from inside either TUI via `/ui ink` or `/ui camouflage`;
-   * takes effect on the next launch (the choice is baked at process start).
+   * Deprecated/ignored. React Ink is always used. Camouflage UI access is
+   * temporarily disabled, so `--ui`, `KIMIFLARE_UI`, and this field have no
+   * effect. Kept in the type so existing configs do not break on load.
    */
   uiEngine?: "ink" | "camouflage";
   /** Per-provider API keys forwarded to AI Gateway as cf-aig-authorization for BYOK. */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,8 +23,7 @@ program
   .option("--max-input-tokens <n>", "cumulative prompt token budget; exits 42 when exhausted (print mode only)", (v) => parseInt(v, 10))
   .option("--emit-events", "emit Camouflage NDJSON events to stdout; requires -p (for initial prompt)")
   .option("--multi-turn", "with --emit-events: keep reading stdin for UserInputSubmitted follow-ups after the initial turn")
-  .option("--ui <name>", "render UI with the given engine: `ink` (default, stable) or `camouflage` (experimental Rust TUI). Can also be set via the KIMIFLARE_UI environment variable.")
-  .option("--camouflage-bin <path>", "with --ui camouflage: path to the camouflage-tui binary (defaults to PATH lookup)")
+  .option("--ui <name>", "render UI with React Ink (the only supported engine). This flag and KIMIFLARE_UI are currently ignored.")
   .option("--mode <mode>", "run mode: interactive (default), print, rpc")
   .option("-c, --continue", "continue the most recent session in the current working directory (print mode only)")
   .option("-S, --session <id>", "resume a specific session by id (print mode only)")
@@ -94,21 +93,10 @@ logsCmd
 
 program
   .command("resume")
-  .description("Pick a session to resume via Camouflage's SelectList primitive (CC-1 demo). Prints chosen session id on stdout, exits 1 on cancel.")
-  .option("--limit <n>", "max recent sessions to list", (v) => parseInt(v, 10), 20)
-  .option("--camouflage-bin <path>", "path to camouflage-tui (defaults to PATH lookup)")
-  .action(async (cmdOpts, command) => {
-    // `--camouflage-bin` is also declared at the top-level program (for
-    // `--ui camouflage` mode), so commander parses the flag against the
-    // parent and never stores it on the subcommand's cmdOpts. Fall back
-    // to the parent's value when the subcommand-level one is undefined.
-    const parentOpts = command?.parent?.opts() ?? {};
-    const bin = cmdOpts.camouflageBin ?? parentOpts.camouflageBin;
-    const { runCamouflageResume } = await import("./camouflage-resume.js");
-    await runCamouflageResume({
-      limit: cmdOpts.limit,
-      camouflageBin: bin,
-    });
+  .description("Resume is temporarily unavailable while Camouflage UI access is disabled.")
+  .action(async () => {
+    console.error("kimiflare resume: temporarily unavailable. Camouflage UI access is disabled.");
+    process.exit(2);
   });
 
 program
@@ -167,7 +155,6 @@ const opts = program.opts<{
   emitEvents?: boolean;
   multiTurn?: boolean;
   ui?: string;
-  camouflageBin?: string;
   mode?: string;
   continue?: boolean;
   session?: string;
@@ -312,69 +299,16 @@ async function main() {
   // alt-screen and flash for a fraction of a second.
   const logoText = renderLogo(getAppVersion());
 
-  // UI engine resolution: React Ink is the default for all users.
-  // Camouflage is strictly opt-in via `--ui camouflage` or the `KIMIFLARE_UI`
-  // env var. We deliberately do NOT let a persisted `uiEngine: "camouflage"`
-  // field in ~/.config/kimiflare/config.json silently switch users to the
-  // experimental engine on the next launch.
-  const explicitUi = opts.ui ?? process.env.KIMIFLARE_UI;
-  const uiEngine = (
-    explicitUi ?? (cfg?.uiEngine === "ink" ? "ink" : undefined) ?? "ink"
-  ).toLowerCase();
-  if (uiEngine !== "camouflage") {
-    console.log(logoText);
-  }
-  if (uiEngine === "camouflage") {
-    // Loud warning that this is experimental and how to bail. Printed
-    // before Camouflage takes the alt-screen so it lands in scrollback;
-    // also emitted as a persistent warn-toast inside the TUI itself
-    // (see ui-mode.ts) so the user sees it even if scrollback was
-    // cleared.
-    process.stderr.write(
-      "\n\x1b[1;33m⚠  Camouflage UI is experimental.\x1b[0m\n" +
-        "   If anything looks broken, switch back any time with:\n" +
-        "     \x1b[1mkimiflare --ui ink\x1b[0m\n" +
-        "   or unset KIMIFLARE_UI if you've exported it.\n" +
-        "   Report issues at https://github.com/sinameraji/camouflage/issues\n\n",
-    );
-    // Brief pause so the warning isn't wiped off the alt-screen
-    // before the user reads it.
-    await new Promise((r) => setTimeout(r, 1200));
-    if (!cfg) {
-      // Run Camouflage-native onboarding (ports the Ink Onboarding flow).
-      // On cancel/exit, the user falls back to the env-var path or
-      // `--ui ink` for the legacy onboarding.
-      const { runCamouflageOnboarding } = await import("./ui-mode.js");
-      const saved = await runCamouflageOnboarding({ camouflageBin: opts.camouflageBin });
-      if (!saved) {
-        console.error(
-          "kimiflare: onboarding cancelled.\n" +
-            "Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, or run again to retry.\n" +
-            "Default Ink onboarding: `kimiflare` (no flag).",
-        );
-        process.exit(2);
-      }
-      cfg = saved;
-    }
-    const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
-    const { runUiMode } = await import("./ui-mode.js");
-    await runUiMode({
-      accountId: cfg.accountId,
-      apiToken: cfg.apiToken,
-      model,
-      // Optional: -p seeds an initial prompt; otherwise the user types into
-      // the renderer's input box.
-      prompt: opts.print,
-      allowAll: !!opts.dangerouslyAllowAll,
-      codeMode: cfg.codeMode,
-      continueOnLimit: !!opts.continueOnLimit,
-      maxInputTokens: opts.maxInputTokens,
-      camouflageBin: opts.camouflageBin,
-      splash: logoText,
-    });
-    return;
-  }
-  // Legacy Ink UI fallback (`--ui ink`).
+  // UI engine resolution: React Ink is always used. Camouflage UI access is
+  // temporarily disabled, so `--ui`, `KIMIFLARE_UI`, and any persisted
+  // `uiEngine: "camouflage"` config value are ignored.
+  const uiEngine = "ink";
+  console.log(logoText);
+  // Camouflage UI branch is temporarily disabled.
+  // if (uiEngine === "camouflage") {
+  //   ...
+  // }
+  // React Ink UI.
   const { renderApp } = await import("./app.js");
   if (cfg) {
     const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -1,13 +1,17 @@
 /**
  * Camouflage UI mode.
  *
+ * NOTE: This module is temporarily unused. Camouflage UI access is disabled
+ * and KimiFlare always launches in React Ink. The code is preserved so it can
+ * be re-enabled later.
+ *
  * Like `--emit-events --multi-turn` but instead of writing NDJSON to stdout
  * for some external consumer to pipe, this mode spawns the Camouflage
  * renderer as a child process via the `camouflage` Node SDK. The renderer
  * draws directly to the user's terminal — single command, single process
  * tree, no plumbing visible to the user.
  *
- * Invocation:
+ * Invocation (currently disabled):
  *     kimiflare --ui camouflage -p "do X"   (opt-in; default is --ui ink)
  *
  * Bidirectional out of the box: typing into the renderer's input box →

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -136,7 +136,6 @@ const CATEGORIES: Category[] = [
       { command: "/cost", description: "show cost report" },
       { command: "/model", description: "show current model" },
       { command: "/update", description: "check for updates" },
-      { command: "/update camouflage", description: "check for camouflage-tui updates" },
       { command: "/hello", description: "send a voice note to the creator" },
     ],
   },

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -65,7 +65,7 @@ import {
 import { HOOK_EVENTS } from "../hooks/types.js";
 import type { AbortScope } from "../util/abort-scope.js";
 import type { CustomCommand } from "../commands/types.js";
-import { checkForUpdate, checkOptionalDependency } from "../util/update-check.js";
+import { checkForUpdate } from "../util/update-check.js";
 import { getAppVersion } from "../util/version.js";
 import {
   detectGitHubRepo,
@@ -111,7 +111,6 @@ export interface SlashContext {
 
   // Modal setters
   setShowThemePicker: (v: boolean) => void;
-  setShowUiPicker: (v: boolean) => void;
   setShowModelPicker: (v: boolean) => void;
   setShowModePicker: (v: boolean) => void;
   setKeyEntryFor: (v: ModelEntry | null) => void;
@@ -808,50 +807,38 @@ const handleTheme: Handler = (ctx, _rest, arg) => {
 
 const handleUi: Handler = (ctx, _rest, arg) => {
   const { setEvents, mkKey } = ctx;
-  // No-arg form opens the arrow-key picker (matches `/theme`, `/resume`).
-  // Direct-arg form is still supported for muscle-memory and scripts.
-  if (!arg) {
-    ctx.setShowUiPicker(true);
-    return true;
-  }
-  if (arg !== "ink" && arg !== "camouflage") {
+  // Camouflage UI access is temporarily disabled; only Ink is available.
+  if (!arg || arg === "ink") {
+    ctx.setCfg((prev) => {
+      if (!prev) return prev;
+      const updated = { ...prev, uiEngine: "ink" } as Cfg;
+      void saveConfig(updated).catch(() => {});
+      return updated;
+    });
     setEvents((e) => [
       ...e,
-      { kind: "info", key: mkKey(), text: `unknown UI engine "${arg}" — choose "ink" or "camouflage"` },
+      {
+        kind: "info",
+        key: mkKey(),
+        text: "UI engine set to \"ink\". React Ink is the only available engine.",
+      },
     ]);
     return true;
   }
-  const next = arg as "ink" | "camouflage";
-  if (next === "camouflage") {
-    // Camouflage is strictly opt-in via CLI flag or env var; we do not persist
-    // it so it can never become the silent default for users.
+  if (arg === "camouflage") {
     setEvents((e) => [
       ...e,
       {
         kind: "error",
         key: mkKey(),
-        text:
-          "Camouflage is experimental and must be opted into explicitly. " +
-          "Launch with `kimiflare --ui camouflage` or set `KIMIFLARE_UI=camouflage`.",
+        text: "Camouflage UI is temporarily unavailable.",
       },
     ]);
     return true;
   }
-  ctx.setCfg((prev) => {
-    if (!prev) return prev;
-    const updated = { ...prev, uiEngine: next } as Cfg;
-    void saveConfig(updated).catch(() => {});
-    return updated;
-  });
-  // Loud red "error"-kind event so the user can't miss that they need to
-  // restart.
   setEvents((e) => [
     ...e,
-    {
-      kind: "error",
-      key: mkKey(),
-      text: `UI engine set to "${next}". RESTART kimiflare for it to take effect.`,
-    },
+    { kind: "info", key: mkKey(), text: `unknown UI engine "${arg}" — only "ink" is available` },
   ]);
   return true;
 };
@@ -1172,22 +1159,10 @@ const handleInit: Handler = (ctx) => {
 const handleUpdate: Handler = (ctx, _rest, arg) => {
   const { setEvents, mkKey } = ctx;
   if (arg === "camouflage") {
-    void checkOptionalDependency("camouflage-tui", "beta").then((dep) => {
-      if (dep.hasUpdate && dep.latestVersion) {
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: `camouflage-tui update available: ${dep.localVersion} → ${dep.latestVersion}` },
-        ]);
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "run:  npm update camouflage-tui" },
-        ]);
-      } else if (dep.localVersion) {
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `camouflage-tui up to date (${dep.localVersion})` }]);
-      } else {
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "camouflage-tui is not installed" }]);
-      }
-    });
+    setEvents((e) => [
+      ...e,
+      { kind: "error", key: mkKey(), text: "Camouflage UI is temporarily unavailable; no update checks for camouflage-tui." },
+    ]);
     return true;
   }
   void checkForUpdate(true).then((result) => {

--- a/src/ui/ui-picker.tsx
+++ b/src/ui/ui-picker.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 
-export type UiEngineChoice = "ink" | "camouflage";
+export type UiEngineChoice = "ink";
 
 interface Props {
   current: UiEngineChoice;
@@ -22,11 +22,6 @@ export function UiPicker({ current, onPick }: Props) {
       label: "React Ink",
       value: "ink",
       description: "stable — current default",
-    },
-    {
-      label: "Camouflage",
-      value: "camouflage",
-      description: "experimental — opt in with `kimiflare --ui camouflage`",
     },
     { label: "< Back", value: "__back__", description: "" },
   ];


### PR DESCRIPTION
Temporarily hides every user-facing Camouflage entry point and makes KimiFlare always launch in React Ink.

### Changes
- Remove `--camouflage-bin` option and update `--ui` help to only mention Ink.
- Force `uiEngine = "ink"`, ignoring `--ui`, `KIMIFLARE_UI`, and persisted config.
- Comment out the Camouflage UI branch in `src/index.tsx`.
- Make `kimiflare resume` print that resume is temporarily unavailable.
- Update `src/config.ts` docs to note `uiEngine` is deprecated/ignored.
- Reject `/ui camouflage` and `/update camouflage` inside Ink.
- Remove Camouflage item from UI picker and `/update camouflage` help line.
- Disable `camouflage-tui` update checks in `app.tsx`.
- Update `/ui` builtin description and `camouflage-resume` stub.
- Add note to `ui-mode.ts` that the module is temporarily unused.

### Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `node bin/kimiflare.mjs --help` no longer lists `camouflage`.
- `KIMIFLARE_UI=camouflage node bin/kimiflare.mjs --help` behaves the same.
- Relevant tests pass.

Co-authored-by: kimiflare <kimiflare@proton.me>