### PR TITLE
fix(ui): prevent ghost text when input wraps across multiple lines

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { Box, Text, useApp, useInput, render } from "ink";
+import { Box, Text, useApp, useInput, useWindowSize, render } from "ink";
 
 import { runAgentTurn, AgentLoopError } from "./agent/loop.js";
 import type { GatewayMeta } from "./agent/client.js";
@@ -219,6 +219,7 @@ function App({
   initialLspProjectPath: string | null;
 }) {
   const { exit } = useApp();
+  const { columns } = useWindowSize();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
   const modelContextLimit = useMemo(
     () => (cfg ? getModelOrInfer(cfg.model).contextWindow : CONTEXT_LIMIT),
@@ -2813,6 +2814,7 @@ function App({
               onChange={setInput}
               onSubmit={submit}
               enablePaste
+              width={columns && columns > 2 ? columns - 2 : undefined}
               cursorOffset={cursorOffset}
               onCursorChange={setCursorOffset}
               pickerActive={picker.isActive}

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Text, useInput, usePaste } from "ink";
+import { Box, Text, useInput, usePaste } from "ink";
 import chalk from "chalk";
 
 interface Props {
@@ -20,6 +20,7 @@ interface Props {
   onPickerSelect?: () => void;
   onPickerCancel?: () => void;
   onCancel?: () => void;
+  width?: number;
 }
 
 const PASTE_CHAR_THRESHOLD = 200;
@@ -89,6 +90,7 @@ export function CustomTextInput({
   onPickerSelect,
   onPickerCancel,
   onCancel,
+  width,
 }: Props) {
   const [internalCursor, setInternalCursor] = useState(value.length);
   const cursorOffset = controlledCursor ?? internalCursor;
@@ -332,6 +334,14 @@ export function CustomTextInput({
     renderedValue = chalk.inverse(" ");
   } else if (cursorOffset === displayValue.length) {
     renderedValue += chalk.inverse(" ");
+  }
+
+  if (width !== undefined) {
+    return (
+      <Box width={width}>
+        <Text wrap="wrap">{renderedValue}</Text>
+      </Box>
+    );
   }
 
   return <Text>{renderedValue}</Text>;


### PR DESCRIPTION
Ink v7 incremental rendering doesn't properly clear old wrapped lines when a bare `<Text>` component lets the terminal handle wrapping naturally.

### Changes
- Add optional `width` prop to `CustomTextInput`
- When `width` is provided, wrap `<Text>` in `<Box width={...}>` with `wrap="wrap"` so Ink's layout engine manages wrapping and knows the true line count
- Pass terminal width minus prompt offset from `app.tsx`

### Testing
- `npm run typecheck` passes
- All 21 tests in `text-input.test.tsx` pass (existing tests don't pass `width`, so they exercise the unchanged code path)

Fixes Ink bug #909 with incremental rendering and text wrapping.