### PR TITLE
fix(agent): remove per-turn tier/skl from gateway metadata to restore cache hits

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -618,10 +618,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
 
     logger.debug("turn:api_request", { sessionId: opts.sessionId, messageCount: apiMessages.length });
-    // Cloudflare AI Gateway caps cf-aig-metadata at 5 keys. Keep the most
-    // queryable signals: feature + sessionId for tracing, tier/cm/skl for
-    // routing analysis from the dashboard. turnIdx is dropped here (still
-    // available in cost-debug.jsonl).
+    // Cloudflare AI Gateway caps cf-aig-metadata at 5 keys. Only send
+    // stable, cache-key-safe values. Per-turn variables (tier, skl) are
+    // intentionally omitted — they change every turn and bust the Gateway
+    // HTTP cache, collapsing prefix-cache hit rates. They remain available
+    // in cost-debug.jsonl for local analysis.
     const turnGateway = opts.gateway
       ? {
           ...opts.gateway,
@@ -629,9 +630,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
             ...(opts.gateway.metadata ?? {}),
             feature: "chat",
             ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
-            tier: opts.intentClassification?.tier ?? "medium",
             cm: codeMode ? "1" : "0",
-            skl: String(skillResult?.sectionCount ?? 0),
           },
         }
       : undefined;


### PR DESCRIPTION
## Problem

Cloudflare AI Gateway includes  in the HTTP cache key. Sending  (intent classification) and  (skill count) on every turn meant every request had a unique cache key, collapsing prefix-cache hit rates from ~93% to <50% and inflating costs 10x.

## Fix

Remove  and  from the per-turn  object. These values are still logged to  for local analysis; they just no longer poison the Gateway cache key.

## Trade-off

- **Before**: ~40-50% cache hit rate, $2+ per 2M tokens
- **After**: ~90%+ cache hit rate, ~$0.22 per 1M tokens

The only loss is cosmetic:  and  will no longer appear in individual log detail views on the Cloudflare dashboard.