### PR TITLE
feat(ui): show session context summary on /resume

### DIFF
--- a/src/ui/use-session-manager.test.ts
+++ b/src/ui/use-session-manager.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { extractFirstUserText } from "./use-session-manager.js";
+import { extractFirstUserText, buildLocalResumeSummary } from "./use-session-manager.js";
 import type { ChatMessage } from "../agent/messages.js";
+import type { SessionState } from "../agent/session-state.js";
+import { emptySessionState } from "../agent/session-state.js";
 
 describe("extractFirstUserText", () => {
   it("returns 'session' for empty messages", () => {
@@ -59,5 +61,52 @@ describe("extractFirstUserText", () => {
       { role: "user", content: "second" },
     ];
     assert.strictEqual(extractFirstUserText(msgs), "first");
+  });
+});
+
+describe("buildLocalResumeSummary", () => {
+  it("returns null for empty session state", () => {
+    assert.strictEqual(buildLocalResumeSummary(emptySessionState()), null);
+  });
+
+  it("includes task when set", () => {
+    const state = emptySessionState("Fix auth bug");
+    assert.strictEqual(buildLocalResumeSummary(state), "Task: Fix auth bug");
+  });
+
+  it("includes modified files", () => {
+    const state = emptySessionState();
+    state.files_modified = ["src/auth.ts", "src/auth.test.ts"];
+    assert.strictEqual(
+      buildLocalResumeSummary(state),
+      "Modified: src/auth.ts, src/auth.test.ts",
+    );
+  });
+
+  it("includes next actions (max 3)", () => {
+    const state = emptySessionState();
+    state.next_actions = ["run tests", "update docs", "commit", "deploy"];
+    const result = buildLocalResumeSummary(state);
+    assert.ok(result?.includes("Next: run tests; update docs; commit"));
+    assert.ok(!result?.includes("deploy"));
+  });
+
+  it("combines task, modified files, and next actions", () => {
+    const state = emptySessionState("Refactor API");
+    state.files_modified = ["src/api.ts"];
+    state.next_actions = ["add tests", "update README"];
+    assert.strictEqual(
+      buildLocalResumeSummary(state),
+      "Task: Refactor API | Modified: src/api.ts | Next: add tests; update README",
+    );
+  });
+
+  it("returns null when only empty arrays are present", () => {
+    const state: SessionState = {
+      ...emptySessionState(),
+      files_modified: [],
+      next_actions: [],
+    };
+    assert.strictEqual(buildLocalResumeSummary(state), null);
   });
 });

--- a/src/ui/use-session-manager.ts
+++ b/src/ui/use-session-manager.ts
@@ -24,7 +24,8 @@ import type { DailyUsage } from "../usage-tracker.js";
 import type { ChatEvent } from "./chat.js";
 import { setLogSessionId } from "../util/log-sink.js";
 import type { Mode } from "../mode.js";
-import { DEFAULT_AUTO_FRESH_SUGGESTION_TURNS } from "./app-helpers.js";
+import { DEFAULT_AUTO_FRESH_SUGGESTION_TURNS, gatewayFromConfig } from "./app-helpers.js";
+import { generateContinuationSummary } from "../agent/continuation-summary.js";
 
 /**
  * Pull the first chunk of user text out of a message list — used to
@@ -45,9 +46,37 @@ export function extractFirstUserText(messages: ChatMessage[]): string {
   return "session";
 }
 
+/**
+ * Build a brief, zero-latency summary from session state for display on
+ * `/resume`. Returns `null` when there's nothing useful to show.
+ */
+export function buildLocalResumeSummary(state: SessionState): string | null {
+  const parts: string[] = [];
+  if (state.task) parts.push(`Task: ${state.task}`);
+  if (state.files_modified.length > 0) {
+    parts.push(`Modified: ${state.files_modified.join(", ")}`);
+  }
+  if (state.next_actions.length > 0) {
+    parts.push(`Next: ${state.next_actions.slice(0, 3).join("; ")}`);
+  }
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
 export interface SessionManagerDeps {
-  /** Model name + other config needed at save time. Null while booting. */
-  cfg: { model: string; autoFreshSuggestionTurns?: number } | null;
+  /** Model name + other config needed at save/resume time. Null while booting. */
+  cfg: {
+    model: string;
+    autoFreshSuggestionTurns?: number;
+    accountId?: string;
+    apiToken?: string;
+    plumbingModel?: string;
+    aiGatewayId?: string;
+    aiGatewayCacheTtl?: number;
+    aiGatewaySkipCache?: boolean;
+    aiGatewayCollectLogPayload?: boolean;
+    aiGatewayMetadata?: Record<string, string | number | boolean>;
+    memoryEnabled?: boolean;
+  } | null;
   /** Current agent mode. */
   mode: Mode;
   // Refs the hook needs to read/write at save and resume time. These
@@ -190,6 +219,52 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
           ? `resumed session ${file.id} from checkpoint`
           : `resumed session ${file.id} (${nonSystemCount} msgs)`;
         d.setEvents([{ kind: "info", key: d.mkKey(), text: msg }]);
+
+        // ── Instant local summary from session state ──────────────────────
+        // Gives the user immediate context with zero latency, before the
+        // async LLM summary arrives.
+        const localSummary = buildLocalResumeSummary(d.sessionStateRef.current);
+        if (localSummary) {
+          d.setEvents((es) => [
+            ...es,
+            { kind: "info", key: d.mkKey(), text: localSummary },
+          ]);
+        }
+
+        // ── Async LLM-generated continuation summary ──────────────────────
+        // Reuses the same generateContinuationSummary that /fresh uses.
+        // Injected as a system message so the model has a fresh context
+        // anchor for the next turn — no need to ask "where were we?".
+        if (d.cfg && d.cfg.accountId && d.cfg.apiToken) {
+          d.setEvents((es) => [
+            ...es,
+            { kind: "info", key: d.mkKey(), text: "generating session summary…" },
+          ]);
+          try {
+            const summary = await generateContinuationSummary({
+              messages: d.messagesRef.current,
+              mode: d.mode,
+              accountId: d.cfg.accountId,
+              apiToken: d.cfg.apiToken,
+              model: d.cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+              gateway: gatewayFromConfig(d.cfg as Parameters<typeof gatewayFromConfig>[0]),
+              memoryManager: d.memoryManagerRef.current,
+              memoryEnabled: d.cfg.memoryEnabled,
+            });
+            if (summary) {
+              d.setEvents((es) => [
+                ...es,
+                { kind: "info", key: d.mkKey(), text: summary },
+              ]);
+              d.messagesRef.current.push({
+                role: "system",
+                content: `[session resume summary]\n${summary}`,
+              });
+            }
+          } catch {
+            // Non-fatal — local summary already shown
+          }
+        }
 
         // Suggest /fresh for long auto/edit sessions resumed without a checkpoint
         if (!checkpointId) {


### PR DESCRIPTION
## Summary

When a user runs `/resume` and picks a session, the only feedback was a minimal info event: `"resumed session {id} ({N} msgs)"`. No human-readable context about what the session was about, what's done, or what's next was shown. The user had to ask "where were we?" — and even then the first response was often unhelpful.

This PR adds a **two-tier context summary** on resume:

### 1. Instant local summary (zero latency)
Extracted from session state (`SessionState`) — shows task, modified files, and next actions immediately. Implemented as a pure, testable function `buildLocalResumeSummary`.

### 2. Async LLM-generated continuation summary
Reuses the existing `generateContinuationSummary` from `src/agent/continuation-summary.ts` (the same function `/fresh` uses). The summary is:
- Shown as an info event to the user
- **Injected as a system message** (`[session resume summary]`) at the end of the message list, so the model has a fresh context anchor for the next turn — no need to ask "where were we?"

### Graceful degradation
- If the LLM call fails → local summary is already shown
- If config is missing (`accountId`/`apiToken`) → only local summary shown
- If session state is empty → skips local summary, still attempts LLM summary

## Changes

| File | Change |
|------|--------|
| `src/ui/use-session-manager.ts` | Expanded `cfg` type, added imports, extracted `buildLocalResumeSummary`, added two-tier summary logic in `doResumeSession` |
| `src/ui/use-session-manager.test.ts` | 6 new test cases for `buildLocalResumeSummary` |

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx tsx --test src/ui/use-session-manager.test.ts` — all 13 tests pass
- [ ] Manual: run `/resume`, pick a session with prior state → verify local summary appears instantly, then LLM summary appears a few seconds later
- [ ] Manual: verify model responds correctly to next prompt without needing "where were we?"

Co-authored-by: kimiflare <kimiflare@proton.me>