### PR TITLE
fix(ui): show loading state while resuming session and auto-display summary

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { Box, Text, useApp, useInput, useWindowSize, render } from "ink";
+import Spinner from "ink-spinner";
 
 import { runAgentTurn, AgentLoopError } from "./agent/loop.js";
 import type { GatewayMeta } from "./agent/client.js";
@@ -502,6 +503,7 @@ function App({
     resumeSessions, setResumeSessions,
     checkpointSession, setCheckpointSession,
     checkpointList,
+    resuming, resumingMessage,
     ensureSessionId,
     saveSessionSafe,
     openResumePicker,
@@ -545,6 +547,7 @@ function App({
     showLspWizard ||
     resumeSessions !== null ||
     checkpointSession !== null ||
+    resuming ||
     perm !== null ||
     limitModal !== null ||
     loopModal !== null ||
@@ -2503,6 +2506,19 @@ function App({
       <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <ResumePicker sessions={resumeSessions} onPick={handleResumePick} />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (resuming) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column" padding={1}>
+          <Text color={theme.accent} bold>
+            <Spinner type="dots" /> {resumingMessage}
+          </Text>
+          <Text color={theme.info.color}>Hang tight — summarizing the session so you can pick up where you left off.</Text>
         </Box>
       </ThemeProvider>
     );

--- a/src/ui/use-session-manager.ts
+++ b/src/ui/use-session-manager.ts
@@ -114,6 +114,10 @@ export interface SessionManager {
   setCheckpointList: (c: Checkpoint[]) => void;
   hasPickerOpen: boolean;
 
+  // Resume loading state.
+  resuming: boolean;
+  resumingMessage: string;
+
   // Operations.
   ensureSessionId: () => string;
   saveSessionSafe: () => Promise<void>;
@@ -133,6 +137,8 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
   const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
   const [checkpointSession, setCheckpointSession] = useState<SessionSummary | null>(null);
   const [checkpointList, setCheckpointList] = useState<Checkpoint[]>([]);
+  const [resuming, setResuming] = useState(false);
+  const [resumingMessage, setResumingMessage] = useState("Pulling context…");
 
   // Stash deps in a ref so the public callbacks keep stable identities.
   // Same pattern as M4.1's PermissionController and M4.2's PickerController.
@@ -325,11 +331,23 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
             ...es,
             { kind: "error", key: depsRef.current.mkKey(), text: `failed to load checkpoints: ${(e as Error).message}` },
           ]);
-          await doResumeSession(picked.filePath);
+          setResuming(true);
+          setResumingMessage("Pulling context…");
+          try {
+            await doResumeSession(picked.filePath);
+          } finally {
+            setResuming(false);
+          }
         }
         return;
       }
-      await doResumeSession(picked.filePath);
+      setResuming(true);
+      setResumingMessage("Pulling context…");
+      try {
+        await doResumeSession(picked.filePath);
+      } finally {
+        setResuming(false);
+      }
     },
     [doResumeSession],
   );
@@ -346,11 +364,17 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
         }
         return;
       }
-      if (checkpointId === "__start__") {
-        await doResumeSession(session.filePath);
-        return;
+      setResuming(true);
+      setResumingMessage("Pulling context…");
+      try {
+        if (checkpointId === "__start__") {
+          await doResumeSession(session.filePath);
+          return;
+        }
+        await doResumeSession(session.filePath, checkpointId);
+      } finally {
+        setResuming(false);
       }
-      await doResumeSession(session.filePath, checkpointId);
     },
     [checkpointSession, doResumeSession],
   );
@@ -373,6 +397,8 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
     checkpointSession, setCheckpointSession,
     checkpointList, setCheckpointList,
     hasPickerOpen: resumeSessions !== null || checkpointSession !== null,
+    resuming,
+    resumingMessage,
     ensureSessionId,
     saveSessionSafe,
     openResumePicker,


### PR DESCRIPTION
When a user selects a session to resume, show a spinner with 'Pulling context…' while the session loads and the continuation summary is generated. The chat view with the summary is then shown automatically, so users no longer need to send a message first.

- Adds `resuming` / `resumingMessage` state to `useSessionManager`
- Renders a loading screen in `app.tsx` during resume
- Includes `resuming` in `modalActive` so pickers stay disabled

Verified with `npm run typecheck`, `npx tsx --test src/ui/use-session-manager.test.ts`, and `npm run build`.

Co-authored-by: kimiflare <kimiflare@proton.me>