### PR TITLE
feat: remove multi-agent-experimental from mode cycle

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1014,13 +1014,7 @@ function App({
       return;
     }
     if (key.shift && key.tab) {
-      setMode((m) => {
-        const next = nextMode(m);
-        if (next === "multi-agent-experimental" && !cfg?.multiAgentEnabled) {
-          return nextMode(next);
-        }
-        return next;
-      });
+      setMode((m) => nextMode(m));
       return;
     }
     if (key.ctrl && inputChar === "o") {
@@ -2687,7 +2681,6 @@ function App({
         currentModel={cfg?.model ?? ""}
         onPickModel={handleModelPick}
         currentMode={mode}
-        multiAgentEnabled={cfg?.multiAgentEnabled}
         onPickMode={(m) => {
           if (m) {
             setMode(m);

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -8,7 +8,7 @@ import type { SlashItem } from "./types.js";
 export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "help", description: "Show keybindings and command list", source: "builtin" },
   { name: "model", argHint: "[list|<id>]", description: "Pick model (no args opens picker)", source: "builtin" },
-  { name: "mode", argHint: "edit|plan|auto|multi-agent-experimental", description: "Switch agent mode", source: "builtin" },
+  { name: "mode", argHint: "edit|plan|auto", description: "Switch agent mode", source: "builtin" },
   { name: "multi-agent", argHint: "[enable|disable|status|setup]", description: "Configure multi-agent (endpoint, auto-implement, set up)", source: "builtin" },
   { name: "theme", argHint: "[<name>]", description: "Switch color theme", source: "builtin" },
   { name: "ui", argHint: "ink", description: "Switch UI engine to React Ink (takes effect on next launch). Camouflage is temporarily unavailable.", source: "builtin" },

--- a/src/mode.test.ts
+++ b/src/mode.test.ts
@@ -112,8 +112,7 @@ describe("nextMode", () => {
   it("cycles through modes", () => {
     assert.strictEqual(nextMode("edit"), "plan");
     assert.strictEqual(nextMode("plan"), "auto");
-    assert.strictEqual(nextMode("auto"), "multi-agent-experimental");
-    assert.strictEqual(nextMode("multi-agent-experimental"), "edit");
+    assert.strictEqual(nextMode("auto"), "edit");
   });
 });
 

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -1,6 +1,6 @@
 export type Mode = "edit" | "plan" | "auto" | "multi-agent-experimental";
 
-export const MODES: Mode[] = ["edit", "plan", "auto", "multi-agent-experimental"];
+export const MODES: Mode[] = ["edit", "plan", "auto"];
 
 export function nextMode(m: Mode): Mode {
   const i = MODES.indexOf(m);

--- a/src/ui/modal-host.tsx
+++ b/src/ui/modal-host.tsx
@@ -72,7 +72,6 @@ export interface ModalHostProps {
   // Mode picker
   currentMode: import("../mode.js").Mode;
   onPickMode: (mode: import("../mode.js").Mode | null) => void;
-  multiAgentEnabled?: boolean;
   // Key entry modal (opens after a byok model is picked without a stored key)
   onSaveProviderKey: (model: ModelEntry, result: KeyResult) => void;
   onCancelKeyEntry: () => void;
@@ -440,7 +439,7 @@ export function ModalHost(props: ModalHostProps): React.ReactElement | null {
     return (
       <ThemeProvider theme={theme}>
         <Box flexDirection="column">
-          <ModePicker current={props.currentMode} onPick={props.onPickMode} multiAgentEnabled={props.multiAgentEnabled} />
+          <ModePicker current={props.currentMode} onPick={props.onPickMode} />
         </Box>
       </ThemeProvider>
     );

--- a/src/ui/mode-picker.tsx
+++ b/src/ui/mode-picker.tsx
@@ -7,12 +7,11 @@ import { useTheme } from "./theme-context.js";
 interface Props {
   current: Mode;
   onPick: (mode: Mode | null) => void;
-  multiAgentEnabled?: boolean;
 }
 
-export function ModePicker({ current, onPick, multiAgentEnabled }: Props) {
+export function ModePicker({ current, onPick }: Props) {
   const theme = useTheme();
-  const availableModes = multiAgentEnabled ? MODES : MODES.filter((m) => m !== "multi-agent-experimental");
+  const availableModes = MODES;
   const items = availableModes.map((m) => ({
     label: `${m === current ? "● " : "  "}${modeDescription(m)}`,
     value: m,

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -701,7 +701,7 @@ const handleMode: Handler = (ctx, _rest, arg) => {
     ctx.setShowModePicker(true);
     return true;
   }
-  if (arg === "edit" || arg === "plan" || arg === "auto" || arg === "multi-agent-experimental") {
+  if (arg === "edit" || arg === "plan" || arg === "auto") {
     const prevMode = mode;
     ctx.setMode(arg);
     setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `mode: ${arg}` }]);
@@ -717,7 +717,7 @@ const handleMode: Handler = (ctx, _rest, arg) => {
     }
     return true;
   }
-  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto|multi-agent-experimental" }]);
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto" }]);
   return true;
 };
 
@@ -750,7 +750,6 @@ const handleMultiAgent: Handler = (ctx, rest, _arg) => {
   }
   if (sub === "disable") {
     persist({ multiAgentEnabled: false }, "multi-agent disabled");
-    if (mode === "multi-agent-experimental") setMode("edit");
     return true;
   }
   if (sub === "execute") {

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -41,7 +41,7 @@ export function StatusBar({ usage, sessionUsage, thinking, turnStartedAt, mode, 
   const theme = useTheme();
   const [now, setNow] = useState(Date.now());
   const modeColor =
-    mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : mode === "multi-agent-experimental" ? theme.modeBadge.auto : theme.modeBadge.edit;
+    mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
   const warn = usage && usage.prompt_tokens / contextLimit >= 0.8;
 
   useEffect(() => {
@@ -111,7 +111,7 @@ export function StatusBar({ usage, sessionUsage, thinking, turnStartedAt, mode, 
     <Box flexDirection="column">
       <Box>
         <Text color={modeColor} bold>
-          [{mode === "multi-agent-experimental" ? "multi-agent" : mode}]
+          [{mode}]
         </Text>
         <Text> </Text>
         {thinking ? (


### PR DESCRIPTION
Removes multi-agent-experimental from the mode list so only plan, edit, and auto appear in the mode picker and Shift-Tab cycle.

### Changes
- Remove multi-agent from MODES array and nextMode cycle
- Remove multiAgentEnabled prop from ModePicker/ModalHost
- Simplify Shift-Tab handler in app.tsx
- Update /mode command hints and slash command handling
- Clean up status bar multi-agent display fallbacks