### PR TITLE
feat(ui): add Try again button to retryable API errors

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -482,6 +482,7 @@ function App({
   const usageRef = useRef<Usage | null>(null);
   const gatewayMetaRef = useRef<GatewayMeta | null>(null);
   const lastApiErrorRef = useRef<{ httpStatus?: number; code?: number; message: string } | null>(null);
+  const pendingRetryRef = useRef<{ text: string; display: string } | null>(null);
   const updateCheckedRef = useRef(false);
   const sessionStateRef = useRef<SessionState>(emptySessionState());
   const artifactStoreRef = useRef<ArtifactStore>(new ArtifactStore());
@@ -1638,7 +1639,7 @@ function App({
   );
 
   const processMessage = useCallback(
-    async (text: string, displayText?: string, opts?: { queuedKey?: string }) => {
+    async (text: string, displayText?: string, opts?: { queuedKey?: string; isRetry?: boolean }) => {
       if (!cfg) return;
       let trimmed = text.trim();
       if (!trimmed) return;
@@ -1651,7 +1652,7 @@ function App({
       let overrideEffort: ReasoningEffort | undefined;
       let display = displayText?.trim() || trimmed;
 
-      if (trimmed.startsWith("/")) {
+      if (!opts?.isRetry && trimmed.startsWith("/")) {
         const head = trimmed.split(/\s+/)[0]!.toLowerCase();
         const selfManaged = ["/compact", "/init"].includes(head);
         if (await handleSlash(trimmed)) {
@@ -1729,22 +1730,24 @@ function App({
         }
       }
 
-      if (opts?.queuedKey) {
-        setEvents((evts) =>
-          evts.map((e) =>
-            e.kind === "user" && e.key === opts.queuedKey
-              ? { ...e, text: display, images: images.length > 0 ? images : undefined, queued: false }
-              : e,
-          ),
-        );
-      } else {
-        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
-      }
+      if (!opts?.isRetry) {
+        if (opts?.queuedKey) {
+          setEvents((evts) =>
+            evts.map((e) =>
+              e.kind === "user" && e.key === opts.queuedKey
+                ? { ...e, text: display, images: images.length > 0 ? images : undefined, queued: false }
+                : e,
+            ),
+          );
+        } else {
+          setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
+        }
 
-      // LSP nudge: if user references code files and LSP is not configured
-      const nudge = maybeLspNudge(display, cfg?.lspEnabled ?? false, cfg?.lspServers ?? {});
-      if (nudge) {
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: nudge }]);
+        // LSP nudge: if user references code files and LSP is not configured
+        const nudge = maybeLspNudge(display, cfg?.lspEnabled ?? false, cfg?.lspServers ?? {});
+        if (nudge) {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: nudge }]);
+        }
       }
 
       // M6.1: classify intent EARLY so the tier is available to the
@@ -1753,37 +1756,116 @@ function App({
       // actually configured, so this isn't a duplicate cost.
       const classification = classifyIntent(trimmed);
 
-      // UserPromptSubmit hook (veto-able). Fired after we know the
-      // prompt resolves to actual user-message content (post slash /
-      // custom command expansion). A vetoing hook cancels the turn
-      // before any LLM call.
-      if (hooksManagerRef.current.hasEnabledHooks("UserPromptSubmit")) {
-        const promptOutcome = await hooksManagerRef.current.fire(
-          "UserPromptSubmit",
-          {
-            event: "UserPromptSubmit",
-            session_id: sessionIdRef.current,
-            cwd: process.cwd(),
-            prompt: display,
-            tier: classification.tier,
-          },
-          null,
-        );
-        if (promptOutcome.vetoed) {
-          const reason = promptOutcome.vetoReason || "UserPromptSubmit hook blocked the prompt";
+      if (!opts?.isRetry) {
+        // UserPromptSubmit hook (veto-able). Fired after we know the
+        // prompt resolves to actual user-message content (post slash /
+        // custom command expansion). A vetoing hook cancels the turn
+        // before any LLM call.
+        if (hooksManagerRef.current.hasEnabledHooks("UserPromptSubmit")) {
+          const promptOutcome = await hooksManagerRef.current.fire(
+            "UserPromptSubmit",
+            {
+              event: "UserPromptSubmit",
+              session_id: sessionIdRef.current,
+              cwd: process.cwd(),
+              prompt: display,
+              tier: classification.tier,
+            },
+            null,
+          );
+          if (promptOutcome.vetoed) {
+            const reason = promptOutcome.vetoReason || "UserPromptSubmit hook blocked the prompt";
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `hook blocked the prompt: ${reason}` },
+            ]);
+            endTurn();
+            return;
+          }
+        }
+
+        messagesRef.current.push({ role: "user", content });
+
+        // Pre-turn save: ensure session exists even if user exits mid-turn
+        await saveSessionSafe();
+
+        // Occasional gentle nudge about /init (educational, not a warning)
+        turnCounterRef.current += 1;
+        if (
+          turnCounterRef.current % 15 === 0 &&
+          existsSync(join(process.cwd(), "KIMI.md")) &&
+          !kimiMdStale
+        ) {
           setEvents((e) => [
             ...e,
-            { kind: "info", key: mkKey(), text: `hook blocked the prompt: ${reason}` },
+            { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
           ]);
-          endTurn();
-          return;
+        }
+
+        // Auto-fresh suggestion for long auto/edit sessions
+        const autoFreshThreshold = cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
+        if (
+          autoFreshThreshold > 0 &&
+          turnCounterRef.current >= autoFreshThreshold &&
+          (modeRef.current === "auto" || modeRef.current === "edit" || modeRef.current === "multi-agent-experimental") &&
+          !freshSuggestedRef.current
+        ) {
+          freshSuggestedRef.current = true;
+          if (cfg?.autoFreshEnabled) {
+            // Auto-execute /fresh after a silent checkpoint
+            void (async () => {
+              try {
+                const turnIndex = messagesRef.current.length;
+                if (turnIndex > 0) {
+                  const cp: Checkpoint = {
+                    id: `cp_prefresh_${Date.now()}`,
+                    label: "pre-fresh auto-save",
+                    turnIndex,
+                    timestamp: new Date().toISOString(),
+                    sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
+                    artifactStore: serializeArtifactStore(artifactStoreRef.current),
+                  };
+                  ensureSessionId();
+                  const { sessionsDir } = await import("./sessions.js");
+                  const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
+                  await addCheckpoint(filePath, cp);
+                }
+                const summary = await generateContinuationSummary({
+                  messages: messagesRef.current,
+                  mode: modeRef.current,
+                  accountId: cfg.accountId,
+                  apiToken: cfg.apiToken,
+                  model: cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+                  gateway: gatewayFromConfig(cfg),
+                  memoryManager: memoryManagerRef.current,
+                  memoryEnabled: cfg.memoryEnabled,
+                });
+                if (summary) {
+                  executeFreshStart(buildSlashContext(), summary);
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: "Auto-fresh triggered: starting new session with continuation context…" },
+                  ]);
+                }
+              } catch (e) {
+                setEvents((es) => [
+                  ...es,
+                  { kind: "error", key: mkKey(), text: `Auto-fresh failed: ${(e as Error).message}` },
+                ]);
+              }
+            })();
+          } else {
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "info",
+                key: mkKey(),
+                text: `Session has run for ${turnCounterRef.current} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
+              },
+            ]);
+          }
         }
       }
-
-      messagesRef.current.push({ role: "user", content });
-
-      // Pre-turn save: ensure session exists even if user exits mid-turn
-      await saveSessionSafe();
 
       // Recall artifacts before sending if compiled context is enabled
       if (compiledContextRef.current) {
@@ -1795,83 +1877,6 @@ function App({
             ...sessionStateRef.current,
             artifact_index: { ...sessionStateRef.current.artifact_index },
           };
-        }
-      }
-
-      // Occasional gentle nudge about /init (educational, not a warning)
-      turnCounterRef.current += 1;
-      if (
-        turnCounterRef.current % 15 === 0 &&
-        existsSync(join(process.cwd(), "KIMI.md")) &&
-        !kimiMdStale
-      ) {
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
-        ]);
-      }
-
-      // Auto-fresh suggestion for long auto/edit sessions
-      const autoFreshThreshold = cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
-      if (
-        autoFreshThreshold > 0 &&
-        turnCounterRef.current >= autoFreshThreshold &&
-        (modeRef.current === "auto" || modeRef.current === "edit" || modeRef.current === "multi-agent-experimental") &&
-        !freshSuggestedRef.current
-      ) {
-        freshSuggestedRef.current = true;
-        if (cfg?.autoFreshEnabled) {
-          // Auto-execute /fresh after a silent checkpoint
-          void (async () => {
-            try {
-              const turnIndex = messagesRef.current.length;
-              if (turnIndex > 0) {
-                const cp: Checkpoint = {
-                  id: `cp_prefresh_${Date.now()}`,
-                  label: "pre-fresh auto-save",
-                  turnIndex,
-                  timestamp: new Date().toISOString(),
-                  sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
-                  artifactStore: serializeArtifactStore(artifactStoreRef.current),
-                };
-                ensureSessionId();
-                const { sessionsDir } = await import("./sessions.js");
-                const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
-                await addCheckpoint(filePath, cp);
-              }
-              const summary = await generateContinuationSummary({
-                messages: messagesRef.current,
-                mode: modeRef.current,
-                accountId: cfg.accountId,
-                apiToken: cfg.apiToken,
-                model: cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
-                gateway: gatewayFromConfig(cfg),
-                memoryManager: memoryManagerRef.current,
-                memoryEnabled: cfg.memoryEnabled,
-              });
-              if (summary) {
-                executeFreshStart(buildSlashContext(), summary);
-                setEvents((e) => [
-                  ...e,
-                  { kind: "info", key: mkKey(), text: "Auto-fresh triggered: starting new session with continuation context…" },
-                ]);
-              }
-            } catch (e) {
-              setEvents((es) => [
-                ...es,
-                { kind: "error", key: mkKey(), text: `Auto-fresh failed: ${(e as Error).message}` },
-              ]);
-            }
-          })();
-        } else {
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: `Session has run for ${turnCounterRef.current} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
-            },
-          ]);
         }
       }
 
@@ -2290,6 +2295,7 @@ function App({
         },
         {
           onDone: () => {
+            pendingRetryRef.current = null;
             // Fire-and-forget all post-turn housekeeping so the UI returns to
             // idle immediately and the user can type the next message without
             // waiting for compaction, memory recall, or session persistence.
@@ -2491,6 +2497,7 @@ function App({
             ) {
               const err = { httpStatus: e.httpStatus, code: e.code, message: humanizeCloudflareError(e) };
               lastApiErrorRef.current = err;
+              pendingRetryRef.current = { text: trimmed, display };
               setEvents((es) => [
                 ...es,
                 { kind: "api_error", key: mkKey(), ...err },
@@ -2885,6 +2892,17 @@ function App({
     );
   }
 
+  const handleRetry = useCallback(
+    (eventKey: string) => {
+      const pending = pendingRetryRef.current;
+      if (!pending) return;
+      pendingRetryRef.current = null;
+      setEvents((es) => es.filter((e) => e.key !== eventKey));
+      void processMessage(pending.text, pending.display, { isRetry: true });
+    },
+    [processMessage],
+  );
+
   const hasConversation = events.some((e) => e.kind === "user" || e.kind === "assistant");
 
   return (
@@ -2893,7 +2911,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} onUpgrade={handleUpgrade} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} onUpgrade={handleUpgrade} onRetry={handleRetry} />
         )}
         {perm ? (
           <PermissionModal

--- a/src/ui/api-error-message.test.tsx
+++ b/src/ui/api-error-message.test.tsx
@@ -8,7 +8,7 @@ import { resolveTheme } from "./theme.js";
 
 const testTheme = resolveTheme();
 
-function render(props: { message: string; httpStatus?: number; code?: number }): string {
+function renderStatic(props: { message: string; httpStatus?: number; code?: number; onRetry?: () => void }): string {
   return renderToString(
     <ThemeProvider theme={testTheme}>
       <ApiErrorMessage {...props} />
@@ -18,18 +18,63 @@ function render(props: { message: string; httpStatus?: number; code?: number }):
 
 describe("ApiErrorMessage", () => {
   it("renders the error message", () => {
-    const out = render({ message: "Rate limit exceeded" });
+    const out = renderStatic({ message: "Rate limit exceeded" });
     assert.ok(out.includes("Rate limit exceeded"));
   });
 
   it("renders HTTP status and code", () => {
-    const out = render({ message: "Rate limit exceeded", httpStatus: 429, code: 3040 });
+    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, code: 3040 });
     assert.ok(out.includes("HTTP 429"));
     assert.ok(out.includes("code: 3040"));
   });
 
   it("shows the report hint", () => {
-    const out = render({ message: "Something went wrong" });
+    const out = renderStatic({ message: "Something went wrong" });
     assert.ok(out.includes("Type /report to send diagnostic info"));
+  });
+
+  it("shows retry UI for HTTP 429", () => {
+    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, onRetry: () => {} });
+    assert.ok(out.includes("Try again"));
+    assert.ok(out.includes("Dismiss"));
+  });
+
+  it("shows retry UI for code 3040", () => {
+    const out = renderStatic({ message: "Gateway error", code: 3040, onRetry: () => {} });
+    assert.ok(out.includes("Try again"));
+    assert.ok(out.includes("Dismiss"));
+  });
+
+  it("shows retry UI for HTTP 500", () => {
+    const out = renderStatic({ message: "Server error", httpStatus: 500, onRetry: () => {} });
+    assert.ok(out.includes("Try again"));
+    assert.ok(out.includes("Dismiss"));
+  });
+
+  it("does not show retry UI for non-retryable errors", () => {
+    const out = renderStatic({ message: "Bad request", httpStatus: 400, onRetry: () => {} });
+    assert.ok(!out.includes("Try again"));
+    assert.ok(!out.includes("Dismiss"));
+  });
+
+  it("does not show retry UI when onRetry is not provided", () => {
+    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429 });
+    assert.ok(!out.includes("Try again"));
+    assert.ok(!out.includes("Dismiss"));
+  });
+
+  it("renders retry UI only when both retryable and onRetry provided", () => {
+    // Non-retryable + onRetry → no retry UI
+    const nonRetryable = renderStatic({ message: "Bad request", httpStatus: 400, onRetry: () => {} });
+    assert.ok(!nonRetryable.includes("Try again"));
+
+    // Retryable + no onRetry → no retry UI
+    const noHandler = renderStatic({ message: "Rate limit exceeded", httpStatus: 429 });
+    assert.ok(!noHandler.includes("Try again"));
+
+    // Retryable + onRetry → retry UI shown
+    const withHandler = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, onRetry: () => {} });
+    assert.ok(withHandler.includes("Try again"));
+    assert.ok(withHandler.includes("Dismiss"));
   });
 });

--- a/src/ui/api-error-message.tsx
+++ b/src/ui/api-error-message.tsx
@@ -1,20 +1,28 @@
 import React from "react";
 import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 
 interface Props {
   httpStatus?: number;
   code?: number;
   message: string;
+  onRetry?: () => void;
 }
 
-export function ApiErrorMessage({ httpStatus, code, message }: Props) {
+function isRetryable(httpStatus?: number, code?: number): boolean {
+  return httpStatus === 429 || code === 3040 || (httpStatus !== undefined && httpStatus >= 500);
+}
+
+export function ApiErrorMessage({ httpStatus, code, message, onRetry }: Props) {
   const theme = useTheme();
 
   const parts: string[] = [];
   if (httpStatus !== undefined) parts.push(`HTTP ${httpStatus}`);
   if (code !== undefined) parts.push(`code: ${code}`);
   const meta = parts.join(" · ");
+
+  const retryable = isRetryable(httpStatus, code);
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1} marginY={1}>
@@ -29,6 +37,19 @@ export function ApiErrorMessage({ httpStatus, code, message }: Props) {
       <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
         Type /report to send diagnostic info
       </Text>
+      {retryable && onRetry && (
+        <Box marginTop={1}>
+          <SelectInput
+            items={[
+              { label: "Try again", value: "retry" as const },
+              { label: "Dismiss", value: "dismiss" as const },
+            ]}
+            onSelect={(item) => {
+              if (item.value === "retry") onRetry();
+            }}
+          />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -63,13 +63,21 @@ interface Props {
   verbose?: boolean;
   intentTier?: IntentTier;
   onUpgrade?: () => void;
+  onRetry?: (eventKey: string) => void;
 }
 
 function toolSignature(name: string, args: string): string {
   return `${name}:${args}`;
 }
 
-export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier, onUpgrade }: Props) {
+function isRetryableApiError(evt: ChatEvent): boolean {
+  return (
+    evt.kind === "api_error" &&
+    (evt.httpStatus === 429 || evt.code === 3040 || (evt.httpStatus !== undefined && evt.httpStatus >= 500))
+  );
+}
+
+export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier, onUpgrade, onRetry }: Props) {
   const theme = useTheme();
 
   // Detect repetitive tool calls in this turn (≥3 identical signatures)
@@ -94,6 +102,16 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
     }
   }
 
+  // Only the latest retryable api_error gets the retry button.
+  let latestRetryableErrorKey: string | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]!;
+    if (isRetryableApiError(e)) {
+      latestRetryableErrorKey = e.key;
+      break;
+    }
+  }
+
   return (
     <Box flexDirection="column">
       {events.map((e, i) => {
@@ -112,7 +130,16 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
                 </Text>
               </Box>
             )}
-            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} isLastAssistant={i === lastAssistantIndex} onUpgrade={onUpgrade} />
+            <EventView
+              evt={e}
+              showReasoning={showReasoning}
+              verbose={verbose}
+              repeatedSigs={repeatedSigs}
+              intentTier={intentTier}
+              isLastAssistant={i === lastAssistantIndex}
+              onUpgrade={onUpgrade}
+              onRetry={e.key === latestRetryableErrorKey ? onRetry : undefined}
+            />
           </Box>
         );
       })}
@@ -128,6 +155,7 @@ const EventView = React.memo(function EventView({
   intentTier,
   isLastAssistant,
   onUpgrade,
+  onRetry,
 }: {
   evt: ChatEvent;
   showReasoning: boolean;
@@ -136,6 +164,7 @@ const EventView = React.memo(function EventView({
   intentTier?: IntentTier;
   isLastAssistant?: boolean;
   onUpgrade?: () => void;
+  onRetry?: (eventKey: string) => void;
 }) {
   const theme = useTheme();
   if (evt.kind === "user") {
@@ -252,6 +281,7 @@ const EventView = React.memo(function EventView({
         httpStatus={evt.httpStatus}
         code={evt.code}
         message={evt.message}
+        onRetry={onRetry ? () => onRetry(evt.key) : undefined}
       />
     );
   }


### PR DESCRIPTION
feat(ui): add Try again button to retryable API errors

- ApiErrorMessage now renders a SelectInput (Try again / Dismiss) for
  retryable errors (429, code 3040, or >=500) when onRetry is provided.
- ChatView tracks the latest retryable api_error and passes onRetry only
  to that event, preventing stale retries.
- App stores the last user message in pendingRetryRef when a retryable
  API error occurs. handleRetry removes the error banner and re-runs
  processMessage with isRetry: true.
- processMessage skips user-event creation, LSP nudge, hooks, and
  auto-fresh logic on retry turns while still re-classifying intent
  and starting the supervisor turn normally.
- onDone clears pendingRetryRef so successful retries clean up state.

Co-authored-by: kimiflare <kimiflare@proton.me>