### PR TITLE
fix: slash-command crash + restore self-hosted onboarding + Cloud /upgrade UX

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -488,7 +488,6 @@ function App({
   const usageRef = useRef<Usage | null>(null);
   const gatewayMetaRef = useRef<GatewayMeta | null>(null);
   const lastApiErrorRef = useRef<{ httpStatus?: number; code?: number; message: string } | null>(null);
-  const pendingRetryRef = useRef<{ text: string; display: string } | null>(null);
   const updateCheckedRef = useRef(false);
   const sessionStateRef = useRef<SessionState>(emptySessionState());
   const artifactStoreRef = useRef<ArtifactStore>(new ArtifactStore());
@@ -1641,7 +1640,7 @@ function App({
   );
 
   const processMessage = useCallback(
-    async (text: string, displayText?: string, opts?: { queuedKey?: string; isRetry?: boolean }) => {
+    async (text: string, displayText?: string, opts?: { queuedKey?: string }) => {
       if (!cfg) return;
       let trimmed = text.trim();
       if (!trimmed) return;
@@ -1654,7 +1653,7 @@ function App({
       let overrideEffort: ReasoningEffort | undefined;
       let display = displayText?.trim() || trimmed;
 
-      if (!opts?.isRetry && trimmed.startsWith("/")) {
+      if (trimmed.startsWith("/")) {
         const head = trimmed.split(/\s+/)[0]!.toLowerCase();
         const selfManaged = ["/compact", "/init"].includes(head);
         if (await handleSlash(trimmed)) {
@@ -1732,24 +1731,22 @@ function App({
         }
       }
 
-      if (!opts?.isRetry) {
-        if (opts?.queuedKey) {
-          setEvents((evts) =>
-            evts.map((e) =>
-              e.kind === "user" && e.key === opts.queuedKey
-                ? { ...e, text: display, images: images.length > 0 ? images : undefined, queued: false }
-                : e,
-            ),
-          );
-        } else {
-          setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
-        }
+      if (opts?.queuedKey) {
+        setEvents((evts) =>
+          evts.map((e) =>
+            e.kind === "user" && e.key === opts.queuedKey
+              ? { ...e, text: display, images: images.length > 0 ? images : undefined, queued: false }
+              : e,
+          ),
+        );
+      } else {
+        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
+      }
 
-        // LSP nudge: if user references code files and LSP is not configured
-        const nudge = maybeLspNudge(display, cfg?.lspEnabled ?? false, cfg?.lspServers ?? {});
-        if (nudge) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: nudge }]);
-        }
+      // LSP nudge: if user references code files and LSP is not configured
+      const nudge = maybeLspNudge(display, cfg?.lspEnabled ?? false, cfg?.lspServers ?? {});
+      if (nudge) {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: nudge }]);
       }
 
       // M6.1: classify intent EARLY so the tier is available to the
@@ -1758,116 +1755,37 @@ function App({
       // actually configured, so this isn't a duplicate cost.
       const classification = classifyIntent(trimmed);
 
-      if (!opts?.isRetry) {
-        // UserPromptSubmit hook (veto-able). Fired after we know the
-        // prompt resolves to actual user-message content (post slash /
-        // custom command expansion). A vetoing hook cancels the turn
-        // before any LLM call.
-        if (hooksManagerRef.current.hasEnabledHooks("UserPromptSubmit")) {
-          const promptOutcome = await hooksManagerRef.current.fire(
-            "UserPromptSubmit",
-            {
-              event: "UserPromptSubmit",
-              session_id: sessionIdRef.current,
-              cwd: process.cwd(),
-              prompt: display,
-              tier: classification.tier,
-            },
-            null,
-          );
-          if (promptOutcome.vetoed) {
-            const reason = promptOutcome.vetoReason || "UserPromptSubmit hook blocked the prompt";
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `hook blocked the prompt: ${reason}` },
-            ]);
-            endTurn();
-            return;
-          }
-        }
-
-        messagesRef.current.push({ role: "user", content });
-
-        // Pre-turn save: ensure session exists even if user exits mid-turn
-        await saveSessionSafe();
-
-        // Occasional gentle nudge about /init (educational, not a warning)
-        turnCounterRef.current += 1;
-        if (
-          turnCounterRef.current % 15 === 0 &&
-          existsSync(join(process.cwd(), "KIMI.md")) &&
-          !kimiMdStale
-        ) {
+      // UserPromptSubmit hook (veto-able). Fired after we know the
+      // prompt resolves to actual user-message content (post slash /
+      // custom command expansion). A vetoing hook cancels the turn
+      // before any LLM call.
+      if (hooksManagerRef.current.hasEnabledHooks("UserPromptSubmit")) {
+        const promptOutcome = await hooksManagerRef.current.fire(
+          "UserPromptSubmit",
+          {
+            event: "UserPromptSubmit",
+            session_id: sessionIdRef.current,
+            cwd: process.cwd(),
+            prompt: display,
+            tier: classification.tier,
+          },
+          null,
+        );
+        if (promptOutcome.vetoed) {
+          const reason = promptOutcome.vetoReason || "UserPromptSubmit hook blocked the prompt";
           setEvents((e) => [
             ...e,
-            { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
+            { kind: "info", key: mkKey(), text: `hook blocked the prompt: ${reason}` },
           ]);
-        }
-
-        // Auto-fresh suggestion for long auto/edit sessions
-        const autoFreshThreshold = cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
-        if (
-          autoFreshThreshold > 0 &&
-          turnCounterRef.current >= autoFreshThreshold &&
-          (modeRef.current === "auto" || modeRef.current === "edit" || modeRef.current === "multi-agent-experimental") &&
-          !freshSuggestedRef.current
-        ) {
-          freshSuggestedRef.current = true;
-          if (cfg?.autoFreshEnabled) {
-            // Auto-execute /fresh after a silent checkpoint
-            void (async () => {
-              try {
-                const turnIndex = messagesRef.current.length;
-                if (turnIndex > 0) {
-                  const cp: Checkpoint = {
-                    id: `cp_prefresh_${Date.now()}`,
-                    label: "pre-fresh auto-save",
-                    turnIndex,
-                    timestamp: new Date().toISOString(),
-                    sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
-                    artifactStore: serializeArtifactStore(artifactStoreRef.current),
-                  };
-                  ensureSessionId();
-                  const { sessionsDir } = await import("./sessions.js");
-                  const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
-                  await addCheckpoint(filePath, cp);
-                }
-                const summary = await generateContinuationSummary({
-                  messages: messagesRef.current,
-                  mode: modeRef.current,
-                  accountId: cfg.accountId,
-                  apiToken: cfg.apiToken,
-                  model: cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
-                  gateway: gatewayFromConfig(cfg),
-                  memoryManager: memoryManagerRef.current,
-                  memoryEnabled: cfg.memoryEnabled,
-                });
-                if (summary) {
-                  executeFreshStart(buildSlashContext(), summary);
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: "Auto-fresh triggered: starting new session with continuation context…" },
-                  ]);
-                }
-              } catch (e) {
-                setEvents((es) => [
-                  ...es,
-                  { kind: "error", key: mkKey(), text: `Auto-fresh failed: ${(e as Error).message}` },
-                ]);
-              }
-            })();
-          } else {
-            setEvents((e) => [
-              ...e,
-              {
-                kind: "info",
-                key: mkKey(),
-                text: `Session has run for ${turnCounterRef.current} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
-              },
-            ]);
-          }
+          endTurn();
+          return;
         }
       }
+
+      messagesRef.current.push({ role: "user", content });
+
+      // Pre-turn save: ensure session exists even if user exits mid-turn
+      await saveSessionSafe();
 
       // Recall artifacts before sending if compiled context is enabled
       if (compiledContextRef.current) {
@@ -1879,6 +1797,83 @@ function App({
             ...sessionStateRef.current,
             artifact_index: { ...sessionStateRef.current.artifact_index },
           };
+        }
+      }
+
+      // Occasional gentle nudge about /init (educational, not a warning)
+      turnCounterRef.current += 1;
+      if (
+        turnCounterRef.current % 15 === 0 &&
+        existsSync(join(process.cwd(), "KIMI.md")) &&
+        !kimiMdStale
+      ) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
+        ]);
+      }
+
+      // Auto-fresh suggestion for long auto/edit sessions
+      const autoFreshThreshold = cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
+      if (
+        autoFreshThreshold > 0 &&
+        turnCounterRef.current >= autoFreshThreshold &&
+        (modeRef.current === "auto" || modeRef.current === "edit" || modeRef.current === "multi-agent-experimental") &&
+        !freshSuggestedRef.current
+      ) {
+        freshSuggestedRef.current = true;
+        if (cfg?.autoFreshEnabled) {
+          // Auto-execute /fresh after a silent checkpoint
+          void (async () => {
+            try {
+              const turnIndex = messagesRef.current.length;
+              if (turnIndex > 0) {
+                const cp: Checkpoint = {
+                  id: `cp_prefresh_${Date.now()}`,
+                  label: "pre-fresh auto-save",
+                  turnIndex,
+                  timestamp: new Date().toISOString(),
+                  sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
+                  artifactStore: serializeArtifactStore(artifactStoreRef.current),
+                };
+                ensureSessionId();
+                const { sessionsDir } = await import("./sessions.js");
+                const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
+                await addCheckpoint(filePath, cp);
+              }
+              const summary = await generateContinuationSummary({
+                messages: messagesRef.current,
+                mode: modeRef.current,
+                accountId: cfg.accountId,
+                apiToken: cfg.apiToken,
+                model: cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+                gateway: gatewayFromConfig(cfg),
+                memoryManager: memoryManagerRef.current,
+                memoryEnabled: cfg.memoryEnabled,
+              });
+              if (summary) {
+                executeFreshStart(buildSlashContext(), summary);
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: "Auto-fresh triggered: starting new session with continuation context…" },
+                ]);
+              }
+            } catch (e) {
+              setEvents((es) => [
+                ...es,
+                { kind: "error", key: mkKey(), text: `Auto-fresh failed: ${(e as Error).message}` },
+              ]);
+            }
+          })();
+        } else {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: `Session has run for ${turnCounterRef.current} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
+            },
+          ]);
         }
       }
 
@@ -2299,7 +2294,6 @@ function App({
         },
         {
           onDone: () => {
-            pendingRetryRef.current = null;
             // Fire-and-forget all post-turn housekeeping so the UI returns to
             // idle immediately and the user can type the next message without
             // waiting for compaction, memory recall, or session persistence.
@@ -2618,7 +2612,6 @@ function App({
             ) {
               const err = { httpStatus: e.httpStatus, code: e.code, message: humanizeCloudflareError(e) };
               lastApiErrorRef.current = err;
-              pendingRetryRef.current = { text: trimmed, display };
               setEvents((es) => [
                 ...es,
                 { kind: "api_error", key: mkKey(), ...err },
@@ -3007,17 +3000,6 @@ function App({
     );
   }
 
-  const handleRetry = useCallback(
-    (eventKey: string) => {
-      const pending = pendingRetryRef.current;
-      if (!pending) return;
-      pendingRetryRef.current = null;
-      setEvents((es) => es.filter((e) => e.key !== eventKey));
-      void processMessage(pending.text, pending.display, { isRetry: true });
-    },
-    [processMessage],
-  );
-
   const hasConversation = events.some((e) => e.kind === "user" || e.kind === "assistant");
 
   return (
@@ -3026,7 +3008,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} onUpgrade={handleUpgrade} onRetry={handleRetry} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} onUpgrade={handleUpgrade} />
         )}
         {perm ? (
           <PermissionModal

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -443,9 +443,17 @@ function App({
     if (!cfg?.cloudMode || !initialCloudToken) return;
     let cancelled = false;
     const fetchBudget = async () => {
+      const did = cloudDeviceId ?? initialCloudDeviceId;
+      // If the user is a paying subscriber, provision/refresh their Pro grant
+      // server-side first so the budget below reflects the lifted cap (works
+      // even if the Stripe webhook never reached the worker).
+      try {
+        const { fetchBillingStatus } = await import("./cloud/billing.js");
+        await fetchBillingStatus(initialCloudToken, did);
+      } catch { /* non-fatal — free-tier users have no subscription */ }
       try {
         const { fetchCloudUsage } = await import("./cloud/auth.js");
-        const usage = await fetchCloudUsage(initialCloudToken, cloudDeviceId ?? initialCloudDeviceId);
+        const usage = await fetchCloudUsage(initialCloudToken, did);
         if (usage && !cancelled) {
           setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
         }
@@ -573,8 +581,13 @@ function App({
         description: c.description ?? "",
         source: c.source,
       }));
-    return [...BUILTIN_COMMANDS, ...customs];
-  }, [customCommandsVersion]);
+    // /upgrade only makes sense on KimiFlare Cloud — surface it in the picker
+    // only when the user is in cloud mode (the handler stays available either way).
+    const cloudCommands: SlashItem[] = cfg?.cloudMode
+      ? [{ name: "upgrade", description: "Upgrade to KimiFlare Pro", source: "builtin" }]
+      : [];
+    return [...BUILTIN_COMMANDS, ...cloudCommands, ...customs];
+  }, [customCommandsVersion, cfg?.cloudMode]);
 
   // Preserves the pre-refactor asymmetry: the picker close-on-modal check
   // includes showInboxModal but EXCLUDES showRemoteDashboard and
@@ -1379,6 +1392,32 @@ function App({
           ...e,
           { kind: "info", key: mkKey(), text: "Complete payment in your browser. Your session will activate automatically." },
         ]);
+        // Poll billing status until the subscription activates, then refresh the
+        // budget in place so the user is recognized as Pro without restarting.
+        void (async () => {
+          const { fetchBillingStatus } = await import("./cloud/billing.js");
+          const { fetchCloudUsage } = await import("./cloud/auth.js");
+          for (let i = 0; i < 40; i++) {
+            await new Promise((r) => setTimeout(r, 5000));
+            let status;
+            try {
+              status = await fetchBillingStatus(token, did);
+            } catch {
+              continue;
+            }
+            if (status && (status.status === "active" || status.status === "past_due")) {
+              try {
+                const usage = await fetchCloudUsage(token, did);
+                if (usage) setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+              } catch { /* ignore */ }
+              setEvents((e) => [
+                ...e,
+                { kind: "info", key: mkKey(), text: "✓ KimiFlare Pro is active — your token limit has been upgraded. Thank you!" },
+              ]);
+              return;
+            }
+          }
+        })();
       } else {
         setEvents((e) => [...e, { kind: "error", key: mkKey(), text: "Checkout unavailable. Please try again later." }]);
       }
@@ -1388,7 +1427,7 @@ function App({
         { kind: "error", key: mkKey(), text: `Upgrade failed: ${err instanceof Error ? err.message : String(err)}` },
       ]);
     }
-  }, [cloudToken, cloudDeviceId, initialCloudToken, initialCloudDeviceId, mkKey, setEvents]);
+  }, [cloudToken, cloudDeviceId, initialCloudToken, initialCloudDeviceId, mkKey, setEvents, setCloudBudget]);
 
   const handleSaveProviderKey = useCallback(
     (model: ModelEntry, result: KeyResult) => {

--- a/src/ui/api-error-message.test.tsx
+++ b/src/ui/api-error-message.test.tsx
@@ -8,7 +8,7 @@ import { resolveTheme } from "./theme.js";
 
 const testTheme = resolveTheme();
 
-function renderStatic(props: { message: string; httpStatus?: number; code?: number; onRetry?: () => void }): string {
+function render(props: { message: string; httpStatus?: number; code?: number }): string {
   return renderToString(
     <ThemeProvider theme={testTheme}>
       <ApiErrorMessage {...props} />
@@ -18,63 +18,18 @@ function renderStatic(props: { message: string; httpStatus?: number; code?: numb
 
 describe("ApiErrorMessage", () => {
   it("renders the error message", () => {
-    const out = renderStatic({ message: "Rate limit exceeded" });
+    const out = render({ message: "Rate limit exceeded" });
     assert.ok(out.includes("Rate limit exceeded"));
   });
 
   it("renders HTTP status and code", () => {
-    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, code: 3040 });
+    const out = render({ message: "Rate limit exceeded", httpStatus: 429, code: 3040 });
     assert.ok(out.includes("HTTP 429"));
     assert.ok(out.includes("code: 3040"));
   });
 
   it("shows the report hint", () => {
-    const out = renderStatic({ message: "Something went wrong" });
+    const out = render({ message: "Something went wrong" });
     assert.ok(out.includes("Type /report to send diagnostic info"));
-  });
-
-  it("shows retry UI for HTTP 429", () => {
-    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, onRetry: () => {} });
-    assert.ok(out.includes("Try again"));
-    assert.ok(out.includes("Dismiss"));
-  });
-
-  it("shows retry UI for code 3040", () => {
-    const out = renderStatic({ message: "Gateway error", code: 3040, onRetry: () => {} });
-    assert.ok(out.includes("Try again"));
-    assert.ok(out.includes("Dismiss"));
-  });
-
-  it("shows retry UI for HTTP 500", () => {
-    const out = renderStatic({ message: "Server error", httpStatus: 500, onRetry: () => {} });
-    assert.ok(out.includes("Try again"));
-    assert.ok(out.includes("Dismiss"));
-  });
-
-  it("does not show retry UI for non-retryable errors", () => {
-    const out = renderStatic({ message: "Bad request", httpStatus: 400, onRetry: () => {} });
-    assert.ok(!out.includes("Try again"));
-    assert.ok(!out.includes("Dismiss"));
-  });
-
-  it("does not show retry UI when onRetry is not provided", () => {
-    const out = renderStatic({ message: "Rate limit exceeded", httpStatus: 429 });
-    assert.ok(!out.includes("Try again"));
-    assert.ok(!out.includes("Dismiss"));
-  });
-
-  it("renders retry UI only when both retryable and onRetry provided", () => {
-    // Non-retryable + onRetry → no retry UI
-    const nonRetryable = renderStatic({ message: "Bad request", httpStatus: 400, onRetry: () => {} });
-    assert.ok(!nonRetryable.includes("Try again"));
-
-    // Retryable + no onRetry → no retry UI
-    const noHandler = renderStatic({ message: "Rate limit exceeded", httpStatus: 429 });
-    assert.ok(!noHandler.includes("Try again"));
-
-    // Retryable + onRetry → retry UI shown
-    const withHandler = renderStatic({ message: "Rate limit exceeded", httpStatus: 429, onRetry: () => {} });
-    assert.ok(withHandler.includes("Try again"));
-    assert.ok(withHandler.includes("Dismiss"));
   });
 });

--- a/src/ui/api-error-message.tsx
+++ b/src/ui/api-error-message.tsx
@@ -1,28 +1,20 @@
 import React from "react";
 import { Box, Text } from "ink";
-import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 
 interface Props {
   httpStatus?: number;
   code?: number;
   message: string;
-  onRetry?: () => void;
 }
 
-function isRetryable(httpStatus?: number, code?: number): boolean {
-  return httpStatus === 429 || code === 3040 || (httpStatus !== undefined && httpStatus >= 500);
-}
-
-export function ApiErrorMessage({ httpStatus, code, message, onRetry }: Props) {
+export function ApiErrorMessage({ httpStatus, code, message }: Props) {
   const theme = useTheme();
 
   const parts: string[] = [];
   if (httpStatus !== undefined) parts.push(`HTTP ${httpStatus}`);
   if (code !== undefined) parts.push(`code: ${code}`);
   const meta = parts.join(" · ");
-
-  const retryable = isRetryable(httpStatus, code);
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1} marginY={1}>
@@ -37,19 +29,6 @@ export function ApiErrorMessage({ httpStatus, code, message, onRetry }: Props) {
       <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
         Type /report to send diagnostic info
       </Text>
-      {retryable && onRetry && (
-        <Box marginTop={1}>
-          <SelectInput
-            items={[
-              { label: "Try again", value: "retry" as const },
-              { label: "Dismiss", value: "dismiss" as const },
-            ]}
-            onSelect={(item) => {
-              if (item.value === "retry") onRetry();
-            }}
-          />
-        </Box>
-      )}
     </Box>
   );
 }

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -63,21 +63,13 @@ interface Props {
   verbose?: boolean;
   intentTier?: IntentTier;
   onUpgrade?: () => void;
-  onRetry?: (eventKey: string) => void;
 }
 
 function toolSignature(name: string, args: string): string {
   return `${name}:${args}`;
 }
 
-function isRetryableApiError(evt: ChatEvent): boolean {
-  return (
-    evt.kind === "api_error" &&
-    (evt.httpStatus === 429 || evt.code === 3040 || (evt.httpStatus !== undefined && evt.httpStatus >= 500))
-  );
-}
-
-export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier, onUpgrade, onRetry }: Props) {
+export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier, onUpgrade }: Props) {
   const theme = useTheme();
 
   // Detect repetitive tool calls in this turn (≥3 identical signatures)
@@ -102,16 +94,6 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
     }
   }
 
-  // Only the latest retryable api_error gets the retry button.
-  let latestRetryableErrorKey: string | undefined;
-  for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i]!;
-    if (isRetryableApiError(e)) {
-      latestRetryableErrorKey = e.key;
-      break;
-    }
-  }
-
   return (
     <Box flexDirection="column">
       {events.map((e, i) => {
@@ -130,16 +112,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
                 </Text>
               </Box>
             )}
-            <EventView
-              evt={e}
-              showReasoning={showReasoning}
-              verbose={verbose}
-              repeatedSigs={repeatedSigs}
-              intentTier={intentTier}
-              isLastAssistant={i === lastAssistantIndex}
-              onUpgrade={onUpgrade}
-              onRetry={e.key === latestRetryableErrorKey ? onRetry : undefined}
-            />
+            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} isLastAssistant={i === lastAssistantIndex} onUpgrade={onUpgrade} />
           </Box>
         );
       })}
@@ -155,7 +128,6 @@ const EventView = React.memo(function EventView({
   intentTier,
   isLastAssistant,
   onUpgrade,
-  onRetry,
 }: {
   evt: ChatEvent;
   showReasoning: boolean;
@@ -164,7 +136,6 @@ const EventView = React.memo(function EventView({
   intentTier?: IntentTier;
   isLastAssistant?: boolean;
   onUpgrade?: () => void;
-  onRetry?: (eventKey: string) => void;
 }) {
   const theme = useTheme();
   if (evt.kind === "user") {
@@ -281,7 +252,6 @@ const EventView = React.memo(function EventView({
         httpStatus={evt.httpStatus}
         code={evt.code}
         message={evt.message}
-        onRetry={onRetry ? () => onRetry(evt.key) : undefined}
       />
     );
   }

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -43,7 +43,7 @@ export type ChatEvent =
       key: string;
       used: number;
       limit: number;
-      expiresAt: string;
+      expiresAt?: string;
     }
   | {
       kind: "qrcode";

--- a/src/ui/cloud-quota-message.tsx
+++ b/src/ui/cloud-quota-message.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "./theme-context.js";
 interface Props {
   used: number;
   limit: number;
-  expiresAt: string;
+  expiresAt?: string;
   onUpgrade?: () => void;
 }
 
@@ -15,77 +15,28 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-export function CloudQuotaMessage({ used, limit, expiresAt, onUpgrade }: Props) {
+export function CloudQuotaMessage({ used, limit, onUpgrade }: Props) {
   const theme = useTheme();
-
-  const expires = expiresAt ? new Date(expiresAt) : null;
-  const start = expires
-    ? new Date(expires.getTime() - 7 * 24 * 60 * 60 * 1000)
-    : null;
-
-  const fmt = (d: Date) =>
-    d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-
-  const dateRange = start && expires ? `${fmt(start)} → ${fmt(expires)}` : "this week";
 
   return (
     <Box flexDirection="column" marginY={1}>
       <Text bold color={theme.accent}>
-        You've used your free allocation for this week.
+        You've run out of free credits.
       </Text>
 
       <Box flexDirection="column" marginTop={1}>
-        <Text color={theme.info.color}>
-          Free tier ran from {dateRange}, courtesy of Cloudflare
+        <Text>
+          → KimiFlare Pro: <Text bold>$10/month for 50M tokens</Text>
+          {onUpgrade ? <Text color={theme.info.color}>  ·  type /upgrade</Text> : null}
         </Text>
-        <Text color={theme.info.color}>
-          Workers AI credits. Thanks for trying kimiflare.
+        <Text>
+          → Or self-host with your own Cloudflare account: <Text color={theme.info.color}>kimiflare config set-key &lt;your-key&gt;</Text>
         </Text>
-      </Box>
-
-      <Box flexDirection="column" marginTop={1}>
-        <Text bold>Upgrade to KimiFlare Pro:</Text>
-        <Box paddingLeft={2} flexDirection="column">
-          <Text color={theme.info.color}>
-            → $10/month founding-user price
-          </Text>
-          <Text color={theme.info.color}>
-            → Includes ~50M tokens/month (usage allowance)
-          </Text>
-          <Text color={theme.info.color}>
-            → No Cloudflare account needed
-          </Text>
-        </Box>
-        {onUpgrade ? (
-          <Box marginTop={1}>
-            <Text bold color={theme.accent}>
-              Press Enter or run /upgrade to subscribe
-            </Text>
-          </Box>
-        ) : null}
-      </Box>
-
-      <Box flexDirection="column" marginTop={1}>
-        <Text bold>Keep going with your own Cloudflare API key:</Text>
-        <Box paddingLeft={2} flexDirection="column">
-          <Text color={theme.info.color}>
-            → Set one: kimiflare config set-key &lt;your-key&gt;
-          </Text>
-          <Text color={theme.info.color}>
-            → Get one: https://dash.cloudflare.com/profile/api-tokens
-          </Text>
-          <Text color={theme.info.color}>
-            → Pricing: https://developers.cloudflare.com/workers-ai/platform/pricing/
-          </Text>
-          <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
-            (~$0.95/M input tokens, ~$4.00/M output tokens)
-          </Text>
-        </Box>
       </Box>
 
       <Box marginTop={1}>
         <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
-          Used: {formatTokens(used)} / {formatTokens(limit)} tokens this week.
+          Used: {formatTokens(used)} / {formatTokens(limit)} tokens.
         </Text>
       </Box>
     </Box>

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -22,6 +22,7 @@ interface Props {
 }
 
 type Step =
+  | "mode"
   | "accountId"
   | "apiToken"
   | "routingMode"
@@ -40,7 +41,8 @@ type Step =
 
 export function Onboarding({ onDone, onCancel }: Props) {
   const theme = useTheme();
-  const [step, setStep] = useState<Step>("accountId");
+  const [step, setStep] = useState<Step>("mode");
+  const [modePickIdx, setModePickIdx] = useState(0);
   const [accountId, setAccountId] = useState("");
   const [apiToken, setApiToken] = useState("");
   const [model, setModel] = useState(DEFAULT_MODEL);
@@ -82,6 +84,25 @@ export function Onboarding({ onDone, onCancel }: Props) {
       },
       [onCancel],
     ),
+  );
+
+  // Arrow-key navigation on the top-level mode picker (Cloud vs Self-hosted).
+  useInput(
+    (_input, key) => {
+      if (step !== "mode") return;
+      const total = 2;
+      if (key.upArrow) {
+        setModePickIdx((i) => (i - 1 + total) % total);
+      } else if (key.downArrow) {
+        setModePickIdx((i) => (i + 1) % total);
+      } else if (key.return) {
+        if (modePickIdx === 0) {
+          startCloudAuth();
+        } else {
+          setStep("accountId");
+        }
+      }
+    },
   );
 
   // Arrow-key navigation on the routing-mode picker.
@@ -210,6 +231,27 @@ export function Onboarding({ onDone, onCancel }: Props) {
     void runProbe(trimmed);
   };
 
+  // KimiFlare Cloud device-auth flow (picked at the top-level mode step).
+  // On success we clear any locally-entered Cloudflare creds and mark cloudMode.
+  const startCloudAuth = () => {
+    setStep("cloudAuth");
+    setCloudAuthError(null);
+    void import("../cloud/auth.js").then(({ authenticateDevice }) => {
+      authenticateDevice((status) => {
+        setCloudAuthStatus(status);
+      })
+        .then(() => {
+          setCloudMode(true);
+          setAccountId("");
+          setApiToken("");
+          setStep("confirm");
+        })
+        .catch((err) => {
+          setCloudAuthError(err instanceof Error ? err.message : String(err));
+        });
+    });
+  };
+
   const handleModelPick = (picked: ModelEntry | null) => {
     // Esc / cancel in the picker → keep the current default (a Workers AI
     // model that needs no setup) and skip straight to confirm.
@@ -219,11 +261,13 @@ export function Onboarding({ onDone, onCancel }: Props) {
     }
     setModel(picked.id);
     setPickedEntry(picked);
-    // Same routing logic as the runtime `/model` flow, with cloud mode first:
-    //   workers-ai           → ask billing mode (cloud / unified / byok)
-    //   unified-eligible     → ask billing mode (unified / byok)
-    //   BYOK-only            → straight to key entry
-    if (picked.provider === "workers-ai" || isUnifiedEligible(picked)) {
+    // Self-hosted routing (Cloud is chosen up front at the mode step):
+    //   workers-ai       → nothing more to set up → confirm
+    //   unified-eligible → ask billing mode (Cloudflare credits / BYOK)
+    //   BYOK-only        → straight to key entry
+    if (picked.provider === "workers-ai") {
+      setStep("confirm");
+    } else if (isUnifiedEligible(picked)) {
       setStep("billingChoice");
     } else {
       setStep("keyEntry");
@@ -231,30 +275,13 @@ export function Onboarding({ onDone, onCancel }: Props) {
   };
 
   const handleBillingChoice = (choice: BillingChoice | null) => {
-    // Esc / cancel from the chooser → fall back to BYOK (safest default).
+    // Esc / cancel from the chooser → back to the model picker.
     if (!choice) {
-      setStep("keyEntry");
+      setStep("model");
       return;
     }
-    if (choice === "cloud") {
-      setStep("cloudAuth");
-      setCloudAuthError(null);
-      void import("../cloud/auth.js").then(({ authenticateDevice }) => {
-        authenticateDevice((status) => {
-          setCloudAuthStatus(status);
-        })
-          .then(() => {
-            setCloudMode(true);
-            setAccountId("");
-            setApiToken("");
-            setStep("confirm");
-          })
-          .catch((err) => {
-            setCloudAuthError(err instanceof Error ? err.message : String(err));
-          });
-      });
-      return;
-    }
+    // Cloud is chosen up front now; the chooser only offers Cloudflare credits
+    // (unified) or BYOK for non-Workers-AI models on the AI Gateway path.
     setStep(choice === "unified" ? "unifiedProbe" : "keyEntry");
   };
 
@@ -316,7 +343,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
   };
 
   // Step numbering: keep simple linear count for visible steps.
-  const visibleSteps: Step[] = ["accountId", "apiToken", "routingMode", "model", "confirm"];
+  const visibleSteps: Step[] = ["mode", "accountId", "apiToken", "routingMode", "model", "confirm"];
   const stepIndex = Math.max(1, visibleSteps.indexOf(step) === -1 ? 3 : visibleSteps.indexOf(step) + 1);
   const totalSteps = visibleSteps.length;
 
@@ -334,6 +361,32 @@ export function Onboarding({ onDone, onCancel }: Props) {
       </Text>
 
       <Box marginTop={1} flexDirection="column">
+        {step === "mode" && (
+          <>
+            <Text>How do you want to run kimiflare?</Text>
+            <Text color={theme.info.color}>
+              Use ↑/↓ to navigate, Enter to select.
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              <Text color={modePickIdx === 0 ? theme.palette.primary : undefined}>
+                {modePickIdx === 0 ? "› " : "  "}
+                KimiFlare Cloud — 5,000,000 tokens free
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Sign in with GitHub or email. No Cloudflare account needed. Upgrade to Pro when you run out.
+              </Text>
+              <Text> </Text>
+              <Text color={modePickIdx === 1 ? theme.palette.primary : undefined}>
+                {modePickIdx === 1 ? "› " : "  "}
+                Self-hosted — bring your own Cloudflare account
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Use your Cloudflare Account ID + API token, then pick Workers AI (direct) or AI Gateway.
+              </Text>
+            </Box>
+          </>
+        )}
+
         {step === "accountId" && (
           <>
             <Text>Enter your Cloudflare Account ID</Text>
@@ -583,14 +636,19 @@ export function Onboarding({ onDone, onCancel }: Props) {
               borderColor={theme.info.color}
               paddingX={1}
             >
-              <Text color={theme.info.color}>Account ID: {accountId}</Text>
-              <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
-              <Text color={theme.info.color}>Model: {model}</Text>
-              {aiGatewayId ? (
-                <Text color={theme.info.color}>AI Gateway: {aiGatewayId}</Text>
-              ) : (
-                <Text color={theme.info.color}>Routing: Workers AI (direct)</Text>
+              {!cloudMode && (
+                <>
+                  <Text color={theme.info.color}>Account ID: {accountId}</Text>
+                  <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
+                </>
               )}
+              <Text color={theme.info.color}>Model: {model}</Text>
+              {!cloudMode &&
+                (aiGatewayId ? (
+                  <Text color={theme.info.color}>AI Gateway: {aiGatewayId}</Text>
+                ) : (
+                  <Text color={theme.info.color}>Routing: Workers AI (direct)</Text>
+                ))}
               {cloudMode && (
                 <Text color={theme.info.color}>
                   Billing: KimiFlare Cloud (free 5M tokens, then $10/mo Pro)


### PR DESCRIPTION
Fixes three regressions from PRs merged on 2026-07-09 plus Cloud billing UX gaps.

## 1. Slash commands crashed (`Rendered fewer hooks than expected`)
PR #611 added a `handleRetry` `useCallback` *after* six early returns in `app.tsx`, so any command hitting a modal/resume branch (`/resume`, `/logout`, `/model`, `/theme`, …) rendered fewer hooks and crashed. **Reverted PR #611** in full (clean reverse-apply; nothing merged after it depended on its symbols).

## 2. Self-hosted onboarding was unusable
PR #586 routed Workers-AI models (incl. the default `@cf/moonshotai/kimi-k2.6`) into a billing chooser with no "use the account ID + token I already entered" exit — every non-Cloud option dead-ended. **Restructured onboarding** into a top-level **Cloud vs Self-hosted** choice; self-hosted now goes account ID → token → Workers AI / AI Gateway → model → confirm (Workers-AI goes straight to confirm, as pre-#586).

## 3. Cloud `/upgrade` UX
- `/upgrade` now appears in the slash picker when in cloud mode (was "No matches").
- After `/upgrade`, the CLI polls billing status and refreshes the budget so a paying user is recognized live; it also checks billing status on cloud startup.
- Simplified the cloud-quota message to the essentials (`$10/month for 50M tokens` or self-host).

## 4. Typecheck fix
PR #614 dropped `expiresAt` from the `cloud_quota_exhausted` producer but the type still required it — made it optional.

## Notes
- The `kimiflare-cloud` **worker** changes (Stripe error surfacing, Pro-token grant on active subscription, `/billing/success` + `/billing/cancel` pages, `STRIPE_PRICE_ID` fix) are in the separate worker repo and are **not** part of this PR.
- Verified: `npm run typecheck` and `npm run build` pass. Pre-existing test failures (theme-contrast, supervisor, payload, gateway-status) are unrelated and also fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)