### PR TITLE
feat(cloud): /topup and /manage membership commands

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -584,7 +584,11 @@ function App({
     // /upgrade only makes sense on KimiFlare Cloud — surface it in the picker
     // only when the user is in cloud mode (the handler stays available either way).
     const cloudCommands: SlashItem[] = cfg?.cloudMode
-      ? [{ name: "upgrade", description: "Upgrade to KimiFlare Pro", source: "builtin" }]
+      ? [
+          { name: "upgrade", description: "Upgrade to KimiFlare Pro", source: "builtin" },
+          { name: "topup", description: "Buy a one-time token top-up (+50M)", source: "builtin" },
+          { name: "manage", description: "Manage membership, billing & invoices", source: "builtin" },
+        ]
       : [];
     return [...BUILTIN_COMMANDS, ...cloudCommands, ...customs];
   }, [customCommandsVersion, cfg?.cloudMode]);
@@ -1429,6 +1433,101 @@ function App({
     }
   }, [cloudToken, cloudDeviceId, initialCloudToken, initialCloudDeviceId, mkKey, setEvents, setCloudBudget]);
 
+  const handleTopup = useCallback(async () => {
+    const token = cloudToken ?? initialCloudToken;
+    const did = cloudDeviceId ?? initialCloudDeviceId;
+    if (!token) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: "Cloud authentication required to buy a top-up." },
+      ]);
+      return;
+    }
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "Opening top-up checkout…" }]);
+    try {
+      const { createTopupSession } = await import("./cloud/billing.js");
+      const session = await createTopupSession(token, did);
+      if (session?.url) {
+        const { openBrowser } = await import("./ui/app-helpers.js");
+        openBrowser(session.url);
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "Complete the one-time payment in your browser — your tokens are added automatically." },
+        ]);
+        // Poll usage until the top-up lands (the limit jumps), then refresh in place.
+        const { fetchCloudUsage } = await import("./cloud/auth.js");
+        const baseline = cloudBudget?.limit ?? 0;
+        for (let i = 0; i < 40; i++) {
+          await new Promise((r) => setTimeout(r, 5000));
+          let usage;
+          try {
+            usage = await fetchCloudUsage(token, did);
+          } catch {
+            continue;
+          }
+          if (usage && usage.input_token_limit > baseline) {
+            setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: "✓ Top-up applied — your token balance has been increased. Thank you!" },
+            ]);
+            return;
+          }
+        }
+      } else {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: "Top-up unavailable. Please try again later." }]);
+      }
+    } catch (err) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: `Top-up failed: ${err instanceof Error ? err.message : String(err)}` },
+      ]);
+    }
+  }, [cloudToken, cloudDeviceId, initialCloudToken, initialCloudDeviceId, cloudBudget, mkKey, setEvents, setCloudBudget]);
+
+  const handleManageMembership = useCallback(async () => {
+    const token = cloudToken ?? initialCloudToken;
+    const did = cloudDeviceId ?? initialCloudDeviceId;
+    if (!token) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: "Cloud authentication required to manage your membership." },
+      ]);
+      return;
+    }
+    if (cloudBudget) {
+      const used = cloudBudget.limit - cloudBudget.remaining;
+      const fmt = (n: number) => `${(n / 1_000_000).toFixed(1)}M`;
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `Tokens this period: ${fmt(used)} used · ${fmt(cloudBudget.remaining)} left of ${fmt(cloudBudget.limit)}.` },
+      ]);
+    }
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "Opening your billing portal…" }]);
+    try {
+      const { createCustomerPortalSession } = await import("./cloud/billing.js");
+      const session = await createCustomerPortalSession(token, did);
+      if (session?.url) {
+        const { openBrowser } = await import("./ui/app-helpers.js");
+        openBrowser(session.url);
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "Manage your card, invoices, or cancel anytime in the browser tab that just opened." },
+        ]);
+      } else {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: "Billing portal unavailable. You may not have an active subscription — run /upgrade to start one." },
+        ]);
+      }
+    } catch (err) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: `Couldn't open billing portal: ${err instanceof Error ? err.message : String(err)}` },
+      ]);
+    }
+  }, [cloudToken, cloudDeviceId, initialCloudToken, initialCloudDeviceId, cloudBudget, mkKey, setEvents]);
+
   const handleSaveProviderKey = useCallback(
     (model: ModelEntry, result: KeyResult) => {
       setKeyEntryFor(null);
@@ -1533,6 +1632,8 @@ function App({
     initLsp,
     ensureSessionId,
     upgrade: handleUpgrade,
+    topup: handleTopup,
+    manageMembership: handleManageMembership,
     lspManagerRef,
     mcpManagerRef,
     hooksManagerRef,

--- a/src/cloud/billing.ts
+++ b/src/cloud/billing.ts
@@ -71,6 +71,25 @@ export async function createCheckoutSession(
   return { url: data.url };
 }
 
+export async function createTopupSession(
+  token: string,
+  deviceId?: string,
+): Promise<CheckoutSession | null> {
+  const res = await fetch(`${CLOUD_API_URL}/v1/billing/topup`, {
+    method: "POST",
+    headers: authHeaders(token, deviceId),
+    body: JSON.stringify({}),
+  });
+  await detectKillSwitch(res);
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error || `Top-up failed: ${res.statusText}`);
+  }
+  const data = (await res.json()) as Record<string, unknown>;
+  if (typeof data.url !== "string") return null;
+  return { url: data.url };
+}
+
 export async function createCustomerPortalSession(token: string, deviceId?: string): Promise<PortalSession | null> {
   const res = await fetch(`${CLOUD_API_URL}/v1/billing/portal`, {
     method: "POST",

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -151,6 +151,8 @@ export interface SlashContext {
   initLsp: () => Promise<void> | void;
   ensureSessionId: () => unknown;
   upgrade: () => Promise<void> | void;
+  topup: () => Promise<void> | void;
+  manageMembership: () => Promise<void> | void;
 
   // Refs
   lspManagerRef: React.MutableRefObject<LspManager>;
@@ -1518,6 +1520,16 @@ const handleUpgrade: Handler = (ctx) => {
   return true;
 };
 
+const handleTopup: Handler = (ctx) => {
+  void ctx.topup();
+  return true;
+};
+
+const handleManage: Handler = (ctx) => {
+  void ctx.manageMembership();
+  return true;
+};
+
 const handleCommand: Handler = (ctx, rest) => {
   const { setEvents, mkKey } = ctx;
   const sub = rest[0]?.toLowerCase() ?? "";
@@ -1881,6 +1893,8 @@ const handlers: Record<string, Handler> = {
   "/report": handleReport,
   "/logout": handleLogout,
   "/upgrade": handleUpgrade,
+  "/topup": handleTopup,
+  "/manage": handleManage,
   "/command": handleCommand,
   "/remote": handleRemote,
   "/changelog-image": handleChangelogImage,


### PR DESCRIPTION
Adds the client side of two Cloud billing features. Worker + Stripe changes ship separately in the `kimiflare-cloud` repo.

## `/topup` — one-time token pack
Buys **+50M tokens for $10** as a Stripe **payment-mode** checkout (one-time), so it never creates a second recurring subscription. After opening checkout it polls usage and, when the top-up lands, refreshes the budget in place with `✓ Top-up applied`.

## `/manage` — membership & billing
Prints the user's current token usage, then opens the **Stripe Customer Portal** (update card, download invoices, cancel, change plan) — reusing the pre-existing `createCustomerPortalSession`.

## Wiring
- Both surface in the slash picker **only in cloud mode** (`cfg.cloudMode`).
- `SlashContext` gains `topup` / `manageMembership`; handlers `/topup` and `/manage` registered.
- `billing.ts` gains `createTopupSession` (POST `/v1/billing/topup`).

## Requires (worker/Stripe side, separate)
- Worker `/v1/billing/topup` endpoint + webhook top-up crediting (idempotent via `topups` table).
- A one-time Stripe price set as `STRIPE_TOPUP_PRICE_ID`.

Verified: `npm run typecheck` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)