### PR TITLE
feat(cloud): hide model name and picker in cloud mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -590,7 +590,12 @@ function App({
           { name: "manage", description: "Manage membership, billing & invoices", source: "builtin" },
         ]
       : [];
-    return [...BUILTIN_COMMANDS, ...cloudCommands, ...customs];
+    // In cloud mode the model is managed by KimiFlare Cloud — hide /model so the
+    // user has no visibility into or control over which model is used.
+    const builtins = cfg?.cloudMode
+      ? BUILTIN_COMMANDS.filter((c) => c.name !== "model")
+      : BUILTIN_COMMANDS;
+    return [...builtins, ...cloudCommands, ...customs];
   }, [customCommandsVersion, cfg?.cloudMode]);
 
   // Preserves the pre-refactor asymmetry: the picker close-on-modal check

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -642,7 +642,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
                   <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
                 </>
               )}
-              <Text color={theme.info.color}>Model: {model}</Text>
+              {!cloudMode && <Text color={theme.info.color}>Model: {model}</Text>}
               {!cloudMode &&
                 (aiGatewayId ? (
                   <Text color={theme.info.color}>AI Gateway: {aiGatewayId}</Text>

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -484,6 +484,16 @@ const handleShell: Handler = (ctx, _rest, arg) => {
 
 const handleModel: Handler = (ctx, rest, arg) => {
   const { cfg, setCfg, setEvents, mkKey } = ctx;
+
+  // On KimiFlare Cloud the model is managed for the user — no visibility or control.
+  if (cfg?.cloudMode) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "Model selection isn't available on KimiFlare Cloud — the model is managed for you." },
+    ]);
+    return true;
+  }
+
   const sub = rest[0]?.toLowerCase() ?? "";
 
   // `/model` with no args → open the picker

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -54,7 +54,8 @@ export function StatusBar({ usage, sessionUsage, thinking, turnStartedAt, mode, 
 
   const idleParts: string[] = [];
   if (gitBranch) idleParts.push(gitBranch);
-  if (model) idleParts.push(shortenModelId(model));
+  // In cloud mode the model is managed by KimiFlare Cloud and hidden from the user.
+  if (model && !cloudMode) idleParts.push(shortenModelId(model));
   if (cloudMode) idleParts.push("CLOUD");
   if (codeMode) idleParts.push("CODE");
 


### PR DESCRIPTION
Cloud's `/v1/chat` is pinned server-side to a single model (`@cf/moonshotai/kimi-k2.7-code`) and ignores any client model choice. So the model picker was misleading in Cloud. This makes Cloud fully opaque about the model (Option C):

- **Status bar**: no model id shown in cloud mode (the `CLOUD` badge stays).
- **`/model`**: hidden from the slash picker in cloud mode; if typed manually, it replies "Model selection isn't available on KimiFlare Cloud — the model is managed for you." (the picker modal is only reachable via `/model`, so it can't be opened).
- **Onboarding**: the confirm screen omits the `Model:` line in cloud mode.

Self-hosted is untouched — model selection works exactly as before.

Verified: `npm run typecheck` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)