### PR TITLE
feat(cloud): default to Kimi-K2.7 in cloud mode

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -13,6 +13,7 @@ import {
   type LlmDumpResponse,
 } from "../util/llm-dump.js";
 import { getModelOrInfer, type ModelProvider } from "../models/registry.js";
+import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 
 export type KimiEvent =
   | { type: "gateway_meta"; meta: GatewayMeta }
@@ -246,7 +247,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
             `Your stored ${modelProvider} key is likely invalid or expired. Fix:`,
             `  /keys set ${modelProvider} <new-key>   replace the stored key`,
             `  /keys clear ${modelProvider}           remove it and reopen the picker to paste fresh`,
-            `  /model @cf/moonshotai/kimi-k2.6  switch back to Workers AI (no key needed)`,
+            `  /model ${opts.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL}  switch back to Workers AI (no key needed)`,
           ].join("\n")
         : msg;
       const apiErr = new KimiApiError(`kimiflare: ${wrappedMsg}`, err?.code, res.status);
@@ -357,7 +358,7 @@ const PROVIDER_DOC: Record<string, { name: string; where: string }> = {
   "openai-compatible": { name: "your provider", where: "your provider's dashboard" },
 };
 
-function missingKeyMessage(model: string, provider: string, unifiedAvailable: boolean): string {
+function missingKeyMessage(model: string, provider: string, unifiedAvailable: boolean, cloudMode?: boolean): string {
   const doc = PROVIDER_DOC[provider] ?? { name: "your provider", where: "your provider's dashboard" };
   const lines = [
     `kimiflare: ${model} needs a ${doc.name} API key.`,
@@ -368,7 +369,8 @@ function missingKeyMessage(model: string, provider: string, unifiedAvailable: bo
   if (unifiedAvailable) {
     lines.push(`  2. Enable Cloudflare Unified Billing for this gateway in the CF dashboard, then run:  /keys unified on`);
   }
-  lines.push(`  ${unifiedAvailable ? "3" : "2"}. Switch back to a Workers AI model:  /model @cf/moonshotai/kimi-k2.6`);
+  const fallbackModel = cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
+  lines.push(`  ${unifiedAvailable ? "3" : "2"}. Switch back to a Workers AI model:  /model ${fallbackModel}`);
   return lines.join("\n");
 }
 
@@ -450,7 +452,7 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
       headers["cf-aig-authorization"] = `Bearer ${providerKey}`;
     } else {
       throw new KimiApiError(
-        missingKeyMessage(opts.model, entry.provider, entry.billingMode === "unified"),
+        missingKeyMessage(opts.model, entry.provider, entry.billingMode === "unified", opts.cloudMode),
         undefined,
         401,
       );

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -14,7 +14,7 @@ import * as client from "./client.js";
 import type { AiGatewayOptions } from "./client.js";
 import type { WorkerResultMessage, ChatMessage } from "./messages.js";
 import { detectRepoInfo, type RepoInfo } from "../util/repo-info.js";
-import { loadConfig, resolveWorkerBudgetUsd, type KimiConfig } from "../config.js";
+import { loadConfig, resolveWorkerBudgetUsd, type KimiConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 import type { MemoryManager } from "../memory/manager.js";
 import type { LspManager } from "../lsp/manager.js";
 import type { McpManager } from "../mcp/manager.js";
@@ -390,6 +390,7 @@ export class TurnSupervisor {
                 logger.warn("supervisor:mcp_export_failed", { error: (err as Error).message });
               }
             }
+            const defaultWorkerModel = cfg?.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
             const payload = {
               mode: w.mode,
               task: w.task,
@@ -399,7 +400,7 @@ export class TurnSupervisor {
               budget: { maxCostUsd },
               outputFormat: "structured" as const,
               tools: w.mode === "plan" ? ("read-only" as const) : ("all" as const),
-              model: w.model ?? "@cf/moonshotai/kimi-k2.6",
+              model: w.model ?? defaultWorkerModel,
               // Sandbox-driven worker needs the repo to clone:
               githubToken: repo.token,
               owner: repo.owner,

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -19,7 +19,7 @@ export const CLOUD_API_URL = "https://api.kimiflare.com";
 export const POLL_INTERVAL_MS = 5000;
 export const POLL_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes (RFC 8628 standard)
 
-// Campaign limits for the Kimi-K2.6 launch. These are enforced server-side;
+// Campaign limits for the Kimi-K2.7 launch. These are enforced server-side;
 // the client keeps them here for UI copy and diagnostics.
 export const CLOUD_FREE_TOKENS_PER_USER = 5_000_000;
 export const CLOUD_MAX_USERS = 100;

--- a/src/config.ts
+++ b/src/config.ts
@@ -198,6 +198,7 @@ export interface KimiConfig {
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
+export const DEFAULT_CLOUD_MODEL = "@cf/moonshotai/kimi-k2.7-code";
 export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
 
 export function configPath(): string {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
+import { readFileSync } from "node:fs";
 import { Command } from "commander";
-import { loadConfig, saveConfig, DEFAULT_MODEL } from "./config.js";
+import { loadConfig, saveConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL, configPath } from "./config.js";
 import { isKillSwitchError } from "./util/errors.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
 import { checkForUpdate } from "./util/update-check.js";
@@ -10,13 +11,29 @@ import { renderLogo } from "./ui/logo.js";
 import { runPrintMode } from "./print-mode.js";
 import type { PrintFormat } from "./print-mode.js";
 
+/** Best-effort synchronous check for whether cloud mode is the default.
+ *  Used only for static --help copy; runtime resolution uses loadConfig(). */
+function isCloudModeConfigured(): boolean {
+  if (process.env.KIMIFLARE_CLOUD === "1" || process.env.KIMIFLARE_CLOUD === "true") return true;
+  try {
+    const raw = readFileSync(configPath(), "utf8");
+    const parsed = JSON.parse(raw) as { cloudMode?: boolean };
+    return parsed.cloudMode === true;
+  } catch {
+    return false;
+  }
+}
+
+const helpDefaultModel = isCloudModeConfigured() ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
+const helpModelName = helpDefaultModel === DEFAULT_CLOUD_MODEL ? "Kimi-K2.7" : "Kimi-K2.6";
+
 const program = new Command();
 program
   .name("kimiflare")
-  .description("Terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.")
+  .description(`Terminal coding agent powered by ${helpModelName} on Cloudflare Workers AI.`)
   .version(getAppVersion())
   .option("-p, --print <prompt>", "one-shot mode: send prompt, stream reply to stdout, exit")
-  .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
+  .option("-m, --model <id>", `model id (defaults to ${helpDefaultModel})`)
   .option("--cloud", "use Kimiflare Cloud (api.kimiflare.com) instead of direct Workers AI")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
   .option("--reasoning", "include reasoning in stdout (print mode only)")
@@ -303,7 +320,7 @@ async function main() {
     }
 
     cfg = {
-      ...(cfg ?? { accountId: "", apiToken: "", model: DEFAULT_MODEL, memoryEnabled: false }),
+      ...(cfg ?? { accountId: "", apiToken: "", model: DEFAULT_CLOUD_MODEL, memoryEnabled: false }),
       cloudMode: true,
     };
   }
@@ -331,7 +348,7 @@ async function main() {
       console.error("kimiflare: --emit-events requires credentials.");
       process.exit(2);
     }
-    const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
+    const model = opts.model ?? cfg.model ?? (cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL);
     const { runEmitMode } = await import("./emit-mode.js");
     await runEmitMode({
       accountId: cfg.accountId,
@@ -351,17 +368,18 @@ async function main() {
   }
 
   if (opts.print !== undefined) {
+    const exampleModel = cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
     if (!cfg) {
       console.error(
         "kimiflare: missing credentials.\n" +
           "Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, or write them to\n" +
           "  ~/.config/kimiflare/config.json  (chmod 600)\n" +
-          "  { \"accountId\": \"...\", \"apiToken\": \"...\", \"model\": \"@cf/moonshotai/kimi-k2.6\" }\n" +
+          `  { "accountId": "...", "apiToken": "...", "model": "${exampleModel}" }\n` +
           "Or use cloud mode: kimiflare --cloud -p \"...\"",
       );
       process.exit(2);
     }
-    const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
+    const model = opts.model ?? cfg.model ?? (cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL);
     const format = (opts.format ?? "text") as PrintFormat;
     if (format !== "text" && format !== "json" && format !== "stream-json") {
       console.error(`kimiflare: invalid --format "${format}". Use: text, json, stream-json`);
@@ -419,7 +437,7 @@ async function main() {
   // renderer as a Splash event so it stays visible until the user's
   // first prompt — console.log here would get swallowed by Camouflage's
   // alt-screen and flash for a fraction of a second.
-  const logoText = renderLogo(getAppVersion());
+  const logoText = renderLogo(getAppVersion(), cloudMode);
 
   // UI engine resolution: React Ink is always used. Camouflage UI access is
   // temporarily disabled, so `--ui`, `KIMIFLARE_UI`, and any persisted

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -21,6 +21,7 @@ import {
   countHighSignalMemoriesSince,
 } from "./db.js";
 import { fetchEmbeddings } from "./embeddings.js";
+import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 import { retrieveMemories } from "./retrieval.js";
 import { runCleanup, shouldCleanup } from "./cleanup.js";
 
@@ -36,6 +37,7 @@ export interface MemoryManagerOpts {
   maxAgeDays?: number;
   maxEntries?: number;
   redactSecrets?: boolean;
+  cloudMode?: boolean;
 }
 
 interface LlmOpts {
@@ -161,7 +163,7 @@ export class MemoryManager {
     return {
       accountId: this.opts.accountId,
       apiToken: this.opts.apiToken,
-      model: this.opts.model ?? "@cf/moonshotai/kimi-k2.6",
+      model: this.opts.model ?? (this.opts.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL),
       gateway: this.opts.gateway,
     };
   }

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -54,6 +54,7 @@ export async function createAgentSession(
       embeddingModel: config.memoryEmbeddingModel,
       maxAgeDays: config.memoryMaxAgeDays,
       maxEntries: config.memoryMaxEntries,
+      cloudMode: config.cloudMode,
     });
     memoryManager.open();
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5,6 +5,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { URL } from "node:url";
 import type { KimiConfig } from "../config.js";
+import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 import { runAgentTurn } from "../agent/loop.js";
 import type { AgentCallbacks } from "../agent/loop.js";
 import { buildSystemPrompt } from "../agent/system-prompt.js";
@@ -199,7 +200,7 @@ export function setupRoutes(config: KimiConfig) {
       if (pathname === "/prompt" && method === "POST") {
         const body = (await readBody(req)) as Record<string, unknown>;
         const prompt = typeof body.prompt === "string" ? body.prompt : "";
-        const model = typeof body.model === "string" ? body.model : (config.model ?? "@cf/moonshotai/kimi-k2.6");
+        const model = typeof body.model === "string" ? body.model : (config.model ?? (config.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL));
         const cwd = typeof body.cwd === "string" ? body.cwd : process.cwd();
         const title = typeof body.title === "string" ? body.title : undefined;
         const files = Array.isArray(body.files) ? body.files.filter((f): f is string => typeof f === "string") : [];

--- a/src/tools/spawn-worker.ts
+++ b/src/tools/spawn-worker.ts
@@ -1,7 +1,7 @@
 import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
 import type { WorkerResultMessage } from "../agent/messages.js";
 import { logger } from "../util/logger.js";
-import { loadConfig, resolveWorkerBudgetUsd } from "../config.js";
+import { loadConfig, resolveWorkerBudgetUsd, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 
 interface SpawnWorkerArgs {
   mode: "plan" | "execute";
@@ -119,7 +119,7 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
       },
       model: {
         type: "string",
-        description: "Model to use for the worker. Defaults to @cf/moonshotai/kimi-k2.6.",
+        description: `Model to use for the worker. Defaults to ${DEFAULT_MODEL} (or ${DEFAULT_CLOUD_MODEL} in cloud mode).`,
       },
       branchName: {
         type: "string",
@@ -158,6 +158,7 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
     const timeoutMs = readNumberEnv("KIMIFLARE_WORKER_TIMEOUT_MS") ?? DEFAULT_WORKER_TIMEOUT_MS;
     const cfg = await loadConfig().catch(() => null);
     const budgetUsd = resolveWorkerBudgetUsd(cfg);
+    const defaultModel = cfg?.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
 
     const payload = {
       mode: args.mode,
@@ -166,7 +167,7 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
       budget: { maxCostUsd: budgetUsd },
       outputFormat: args.outputFormat ?? "structured",
       tools: args.tools ?? (args.mode === "plan" ? "read-only" : "all"),
-      model: args.model ?? "@cf/moonshotai/kimi-k2.6",
+      model: args.model ?? defaultModel,
       ...(args.mode === "execute"
         ? {
             branchName: args.branchName,

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -290,6 +290,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
       gateway: gatewayFromConfig(startupCfg),
       maxAgeDays: startupCfg.memoryMaxAgeDays ?? RETENTION.memoryMaxAgeDays,
       maxEntries: startupCfg.memoryMaxEntries ?? RETENTION.memoryMaxEntries,
+      cloudMode: opts.cloudMode,
     });
     memoryManager.open();
     // Run cleanup and backfill in the background (fire-and-forget)

--- a/src/ui/logo.ts
+++ b/src/ui/logo.ts
@@ -27,11 +27,12 @@ const LOGO_ART = `\x1b[49m                                                \x1b[m
 const LOGO_WIDTH = 48;
 
 /** Styled text lines to render beside the logo. */
-function buildTextLines(version: string): string[] {
+function buildTextLines(version: string, cloudMode?: boolean): string[] {
   const accent = "[38;2;255;153;0m";
   const dim = "[2m";
   const reset = "[0m";
   const bold = "[1m";
+  const modelLabel = cloudMode ? "Kimi-K2.7" : "Kimi-K2.6";
 
   return [
     "",
@@ -43,7 +44,7 @@ function buildTextLines(version: string): string[] {
     `  ${bold}${accent}Kimiflare${reset}`,
     "",
     `  ${dim}Terminal coding agent${reset}`,
-    `  ${dim}powered by Kimi-K2.6${reset}`,
+    `  ${dim}powered by ${modelLabel}${reset}`,
     "",
     `  ${dim}v${version}${reset}`,
     "",
@@ -74,9 +75,9 @@ function padVisual(str: string, width: number): string {
 }
 
 /** Render the logo with text appended to the right side. */
-export function renderLogo(version: string): string {
+export function renderLogo(version: string, cloudMode?: boolean): string {
   const logoLines = LOGO_ART.split("\n");
-  const textLines = buildTextLines(version);
+  const textLines = buildTextLines(version, cloudMode);
   const out: string[] = [];
 
   for (let i = 0; i < logoLines.length; i++) {

--- a/src/ui/run-startup-tasks.ts
+++ b/src/ui/run-startup-tasks.ts
@@ -75,6 +75,7 @@ export function runStartupTasks(deps: RunStartupTasksDeps): void {
       gateway: gatewayFromConfig(cfg),
       maxAgeDays: cfg.memoryMaxAgeDays ?? RETENTION.memoryMaxAgeDays,
       maxEntries: cfg.memoryMaxEntries ?? RETENTION.memoryMaxEntries,
+      cloudMode: cfg.cloudMode,
     });
     manager.open();
     memoryManagerRef.current = manager;

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -13,7 +13,7 @@ import { unlink } from "node:fs/promises";
 import QRCode from "qrcode";
 
 import type { Cfg } from "../app.js";
-import { configPath, loadConfig, saveConfig } from "../config.js";
+import { configPath, loadConfig, saveConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 import type { ChatEvent } from "./chat.js";
 import type { ChatMessage, Usage } from "../agent/messages.js";
 import type { GatewayMeta } from "../agent/client.js";
@@ -274,7 +274,7 @@ export function executeFreshStart(
   rebuildSystemPromptForMode(
     ctx.messagesRef.current,
     ctx.cacheStableRef.current,
-    ctx.cfg?.model ?? "@cf/moonshotai/kimi-k2.6",
+    ctx.cfg?.model ?? (ctx.cfg?.cloudMode ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL),
     overrideMode ?? ctx.mode,
     [...ALL_TOOLS, ...ctx.mcpToolsRef.current, ...ctx.lspToolsRef.current],
     ctx.cfg?.preferPullRequests,


### PR DESCRIPTION
When `cloudMode` is enabled (via config or `--cloud`), use `@cf/moonshotai/kimi-k2.7-code` as the default model and surface **Kimi-K2.7** in user-facing copy:

- Logo now shows "powered by Kimi-K2.7" in cloud mode
- `--help` description and `--model` default reflect the cloud default
- Error hints suggesting a Workers AI fallback use the cloud default
- Internal fallbacks (HTTP server, slash commands, spawn-worker, multi-agent workers, memory manager) also respect cloud mode

Self-hosted / direct Workers AI mode keeps `@cf/moonshotai/kimi-k2.6` as the default.