### PR TITLE
fix(plan-mode): defer fresh start until execution mode is picked

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -529,6 +529,11 @@ function App({
   const kimiMdStaleNudgedRef = useRef(false);
   /** Stores the plan distilled from a plan-mode session so it survives follow-up discussion. */
   const sessionPlanRef = useRef<string | null>(null);
+  /**
+   * Plan text bound to the plan-complete picker when it is armed, so a
+   * session reset between arming and picking can't invalidate the pick.
+   */
+  const planCompletePlanRef = useRef<string | null>(null);
 
   const sessionMgr = useSessionManager({
     cfg,
@@ -1684,11 +1689,13 @@ function App({
   const handlePlanCompletePick = useCallback(
     (picked: PlanCompleteChoice | null) => {
       setShowPlanCompletePicker(false);
+      const boundPlan = planCompletePlanRef.current;
+      planCompletePlanRef.current = null;
       if (!picked || picked === "continue") return;
 
-      // Use the plan captured when the picker was first shown so follow-up
-      // discussion doesn't bury the original plan in message history.
-      const plan = resolvePlanForFresh({
+      // Prefer the plan bound to the picker when it was armed (immune to
+      // session resets in between); fall back to resolving from session state.
+      const plan = boundPlan ?? resolvePlanForFresh({
         mode: "plan",
         messages: messagesRef.current,
         sessionPlan: sessionPlanRef.current,
@@ -2695,7 +2702,12 @@ function App({
                     // Non-fatal: the in-session ref is the primary fast path.
                   });
                 }
-                setShowPlanCompletePicker(true);
+                // When the model presented explicit plan options, the option
+                // pick chains into this picker with the chosen plan instead.
+                if (!planOptionsRef.current) {
+                  planCompletePlanRef.current = plan;
+                  setShowPlanCompletePicker(true);
+                }
               }
             }
 
@@ -2870,24 +2882,25 @@ function App({
               setPlanOptions(null);
               planOptionsRef.current = null;
               if (option) {
-                const ctx = buildSlashContext();
-                const clipResult = executeFreshStart(ctx, option.plan);
+                // Defer the fresh start to the plan-complete picker so the
+                // user picks an execution mode first and the session is only
+                // reset once, right before the plan is submitted.
+                sessionPlanRef.current = option.plan;
+                if (cfg?.memoryEnabled && memoryManagerRef.current && sessionIdRef.current) {
+                  void memoryManagerRef.current.rememberPlan(option.plan, process.cwd(), sessionIdRef.current).catch(() => {
+                    // Non-fatal: the in-session ref is the primary fast path.
+                  });
+                }
+                planCompletePlanRef.current = option.plan;
+                setShowPlanCompletePicker(true);
                 setEvents((e) => [
                   ...e,
                   {
                     kind: "info",
                     key: mkKey(),
-                    text: clipResult.success
-                      ? `Plan "${option.label}" copied to clipboard. Starting fresh session with plan only…`
-                      : `Starting fresh session with plan "${option.label}"…`,
+                    text: `Selected plan "${option.label}" — choose how to execute.`,
                   },
                 ]);
-                if (!clipResult.success) {
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: "--- Plan ---\n" + option.plan },
-                  ]);
-                }
               }
             }}
           />

--- a/src/tools/plan-options.ts
+++ b/src/tools/plan-options.ts
@@ -23,7 +23,8 @@ export const presentPlanOptionsTool: ToolSpec<PresentPlanOptionsArgs> = {
     "Present a list of plan options to the user and let them pick one.",
     "Use this when you have multiple viable approaches and want the user to choose",
     "which plan to pursue. Each option needs a short label and the full plan text.",
-    "After the user selects an option, the session resets and starts fresh with the chosen plan.",
+    "After the user selects an option, they choose an execution mode and the",
+    "session starts fresh seeded with the chosen plan.",
   ].join(" "),
   parameters: {
     type: "object",


### PR DESCRIPTION
## Problem

In plan mode, when the model presents multiple approaches via `present_plan_options`, picking one immediately fresh-started the session — wiping `sessionPlanRef` and the message history — while the auto/edit/continue picker stayed armed as a stale leftover. Clicking "Execute this plan (auto mode)" then re-resolved the plan from the wiped state:

- session ref → null (just wiped by `executeFreshStart`)
- durable memory → skipped (`memoryEnabled` defaults to false)
- re-distill from history → null (no assistant message left)

→ `No plan found to start fresh with.`, and the user was dropped into auto mode with a dead session. The option-pick path also seeded the chosen plan but never submitted it, so even without the error the session sat idle, still in plan mode.

## Fix (React Ink UI only)

- **Option pick defers the reset**: it now just records the chosen plan (session ref, durable memory when enabled, and a new `planCompletePlanRef` binding) and chains into the mode picker with "Selected plan … — choose how to execute."
- **Single fresh start at mode pick**: `handlePlanCompletePick` performs the one reset, switches mode, copies the plan to the clipboard, and submits it — execution actually begins.
- **Plan bound at arm time**: the mode picker carries the plan text it was armed with (`planCompletePlanRef`), so no session reset in between can invalidate the pick; `resolvePlanForFresh` remains as fallback.
- **Turn-end guard**: the mode picker is no longer armed while plan options are pending.
- `present_plan_options` tool description updated to match the new flow.

Side benefit: picking an option no longer destroys research context before the user confirms anything — "Chat about this" and "Continue planning" keep full history.

## Testing

- `tsc --noEmit` clean, `tsup` build succeeds.
- `npm test`: 791/793 pass; the 2 failures (theme contrast, status formatting) fail identically on clean `main` — pre-existing, unrelated.
- Manual e2e: in plan mode, ask for a task with 2 plan options → pick one → mode picker appears → pick auto → fresh session starts executing the chosen plan, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)