### PR TITLE
feat(models): add Moonshot Kimi K3 support as AI Gateway BYOK provider

### DIFF
--- a/src/agent/client.providers.test.ts
+++ b/src/agent/client.providers.test.ts
@@ -221,6 +221,36 @@ describe("runKimi: provider auth-header routing (BYOK alias vs raw key vs unifie
     assert.strictEqual(lastRequest!.headers.get("cf-aig-authorization"), null);
     assert.strictEqual(lastRequest!.headers.get("cf-aig-byok-alias"), null);
   });
+
+  it("Moonshot K3: providerKeys.moonshotai sends cf-aig-authorization", async () => {
+    for await (const _ of runKimi({
+      ...baseOpts,
+      model: "moonshotai/kimi-k3",
+      providerKeys: { moonshotai: "sk-moonshot-test" },
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(
+      lastRequest!.headers.get("cf-aig-authorization"),
+      "Bearer sk-moonshot-test",
+    );
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-byok-alias"), null);
+  });
+
+  it("Moonshot K3: unifiedBilling=true is ignored because provider is BYOK-only", async () => {
+    await assert.rejects(
+      async () => {
+        for await (const _ of runKimi({
+          ...baseOpts,
+          model: "moonshotai/kimi-k3",
+          unifiedBilling: true,
+        })) {
+          /* drain */
+        }
+      },
+      (err: Error) => err.message.includes("needs a Moonshot AI API key"),
+    );
+  });
 });
 
 describe("runKimi: Workers AI plumbing routes through gateway when configured", () => {

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -12,7 +12,7 @@ import {
   type LlmDumpRecord,
   type LlmDumpResponse,
 } from "../util/llm-dump.js";
-import { getModelOrInfer, type ModelProvider } from "../models/registry.js";
+import { getModelOrInfer, isUnifiedEligible, type ModelProvider } from "../models/registry.js";
 import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 
 export type KimiEvent =
@@ -355,6 +355,7 @@ const PROVIDER_DOC: Record<string, { name: string; where: string }> = {
   anthropic: { name: "Anthropic", where: "https://console.anthropic.com/settings/keys" },
   openai: { name: "OpenAI", where: "https://platform.openai.com/api-keys" },
   google: { name: "Google AI Studio", where: "https://aistudio.google.com/app/apikey" },
+  moonshotai: { name: "Moonshot AI", where: "https://platform.moonshot.cn/" },
   "openai-compatible": { name: "your provider", where: "your provider's dashboard" },
 };
 
@@ -441,7 +442,11 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
     //   2. Stored Keys      → cf-aig-byok-alias points at a CF Secrets Store secret;
     //                         CF resolves it server-side. We never read the secret.
     //   3. Local BYOK       → cf-aig-authorization carries the raw provider key.
-    const useUnified = !!opts.unifiedBilling;
+    // Only use Unified Billing when the model/provider explicitly supports it.
+    // Some providers (e.g. Moonshot AI) are BYOK-only on AI Gateway, so a
+    // global unifiedBilling=true must not silently send an unauthenticated
+    // request that fails with a generic upstream 503.
+    const useUnified = !!opts.unifiedBilling && isUnifiedEligible(entry);
     const alias = opts.providerKeyAliases?.[entry.provider];
     const providerKey = opts.providerKeys?.[entry.provider];
     if (useUnified) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -112,9 +112,9 @@ export interface AgentTurnOpts {
   cloudToken?: string;
   cloudDeviceId?: string;
   /** Per-provider API keys (BYOK) forwarded to AI Gateway. */
-  providerKeys?: Partial<Record<"workers-ai" | "anthropic" | "openai" | "google" | "openai-compatible", string>>;
+  providerKeys?: Partial<Record<"workers-ai" | "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible", string>>;
   /** Per-provider alias names referencing CF Secrets Store entries (fire-and-forget BYOK). */
-  providerKeyAliases?: Partial<Record<"workers-ai" | "anthropic" | "openai" | "google" | "openai-compatible", string>>;
+  providerKeyAliases?: Partial<Record<"workers-ai" | "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible", string>>;
   /** Whether to use Cloudflare Unified Billing for models that support it. */
   unifiedBilling?: boolean;
   /** Shell override for the bash tool. If omitted, the tool auto-detects based on platform. */

--- a/src/agent/secrets-store.ts
+++ b/src/agent/secrets-store.ts
@@ -158,6 +158,6 @@ export async function deleteProviderKey(
 }
 
 /** Build a deterministic alias name for a provider. */
-export function aliasFor(provider: "anthropic" | "openai" | "google" | "openai-compatible"): string {
+export function aliasFor(provider: "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible"): string {
   return `kimi-code-${provider}`;
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -194,12 +194,14 @@ export interface Cfg {
     anthropic?: string;
     openai?: string;
     google?: string;
+    moonshotai?: string;
     "openai-compatible"?: string;
   };
   providerKeyAliases?: {
     anthropic?: string;
     openai?: string;
     google?: string;
+    moonshotai?: string;
     "openai-compatible"?: string;
   };
   secretsStoreId?: string;
@@ -1541,7 +1543,7 @@ function App({
   const handleSaveProviderKey = useCallback(
     (model: ModelEntry, result: KeyResult) => {
       setKeyEntryFor(null);
-      const provider = model.provider as "anthropic" | "openai" | "google" | "openai-compatible";
+      const provider = model.provider as "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible";
       setCfg((prev) => {
         if (!prev) return prev;
         const updated = { ...prev };

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,7 @@ export interface KimiConfig {
     anthropic?: string;
     openai?: string;
     google?: string;
+    moonshotai?: string;
     "openai-compatible"?: string;
   };
   /** When true, models marked billingMode="unified" use Cloudflare's Unified Billing (no BYOK header). */
@@ -118,6 +119,7 @@ export interface KimiConfig {
     anthropic?: string;
     openai?: string;
     google?: string;
+    moonshotai?: string;
     "openai-compatible"?: string;
   };
   /** Id of the Cloudflare Secrets Store kimi-code uses for provider-key BYOK aliases. */
@@ -198,7 +200,7 @@ export interface KimiConfig {
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
-export const DEFAULT_CLOUD_MODEL = "@cf/moonshotai/kimi-k2.7-code";
+export const DEFAULT_CLOUD_MODEL = "moonshotai/kimi-k3";
 export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
 
 export function configPath(): string {
@@ -238,17 +240,19 @@ function readNumberEnv(name: string): number | undefined {
 }
 
 function readProviderKeysEnv():
-  | { anthropic?: string; openai?: string; google?: string; "openai-compatible"?: string }
+  | { anthropic?: string; openai?: string; google?: string; moonshotai?: string; "openai-compatible"?: string }
   | undefined {
   const anthropic = process.env.ANTHROPIC_API_KEY || process.env.KIMIFLARE_ANTHROPIC_KEY;
   const openai = process.env.OPENAI_API_KEY || process.env.KIMIFLARE_OPENAI_KEY;
   const google = process.env.GOOGLE_API_KEY || process.env.KIMIFLARE_GOOGLE_KEY;
+  const moonshotai = process.env.MOONSHOT_API_KEY || process.env.KIMIFLARE_MOONSHOT_KEY;
   const generic = process.env.KIMIFLARE_OPENAI_COMPAT_KEY;
-  if (!anthropic && !openai && !google && !generic) return undefined;
-  const out: { anthropic?: string; openai?: string; google?: string; "openai-compatible"?: string } = {};
+  if (!anthropic && !openai && !google && !moonshotai && !generic) return undefined;
+  const out: { anthropic?: string; openai?: string; google?: string; moonshotai?: string; "openai-compatible"?: string } = {};
   if (anthropic) out.anthropic = anthropic;
   if (openai) out.openai = openai;
   if (google) out.google = google;
+  if (moonshotai) out.moonshotai = moonshotai;
   if (generic) out["openai-compatible"] = generic;
   return out;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ function isCloudModeConfigured(): boolean {
 }
 
 const helpDefaultModel = isCloudModeConfigured() ? DEFAULT_CLOUD_MODEL : DEFAULT_MODEL;
-const helpModelName = helpDefaultModel === DEFAULT_CLOUD_MODEL ? "Kimi-K2.7" : "Kimi-K2.6";
+const helpModelName = helpDefaultModel === DEFAULT_CLOUD_MODEL ? "Kimi-K3" : "Kimi-K2.6";
 
 const program = new Command();
 program
@@ -180,7 +180,7 @@ program
           await saveConfig({
             accountId: "",
             apiToken: "",
-            model: existing?.model ?? DEFAULT_MODEL,
+            model: existing?.model ?? DEFAULT_CLOUD_MODEL,
             cloudMode: true,
           });
           console.log("Cloud mode enabled. Run `kimiflare` to start using it.");

--- a/src/models/next-step.ts
+++ b/src/models/next-step.ts
@@ -21,7 +21,7 @@ export function decideNextStep(cfg: KimiConfig | null, model: ModelEntry): NextS
   if (!cfg) return { kind: "ready" };
   if (!cfg.aiGatewayId) return { kind: "needs-gateway" };
 
-  const providerKey = model.provider as "anthropic" | "openai" | "google" | "openai-compatible";
+  const providerKey = model.provider as "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible";
   const hasKey = !!cfg.providerKeys?.[providerKey];
   const hasAlias = !!cfg.providerKeyAliases?.[providerKey];
   const usingUnified = !!cfg.unifiedBilling;

--- a/src/models/registry.test.ts
+++ b/src/models/registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getModel, inferProvider, isUnifiedEligible } from "./registry.js";
+
+describe("registry: Moonshot K3", () => {
+  it("infers moonshotai provider from moonshotai/kimi-k3", () => {
+    assert.strictEqual(inferProvider("moonshotai/kimi-k3"), "moonshotai");
+  });
+
+  it("seeds moonshotai/kimi-k3 as BYOK-only (Unified Billing not available)", () => {
+    const model = getModel("moonshotai/kimi-k3");
+    assert.ok(model, "expected moonshotai/kimi-k3 to be seeded");
+    assert.strictEqual(model!.provider, "moonshotai");
+    assert.strictEqual(model!.billingMode, "byok");
+    assert.strictEqual(isUnifiedEligible(model!), false);
+  });
+
+  it("keeps Workers AI Kimi models on the workers-ai provider", () => {
+    assert.strictEqual(inferProvider("@cf/moonshotai/kimi-k2.7-code"), "workers-ai");
+    assert.strictEqual(inferProvider("@cf/moonshotai/kimi-k2.6"), "workers-ai");
+    assert.strictEqual(inferProvider("@cf/moonshotai/kimi-k2.5"), "workers-ai");
+  });
+});

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -3,10 +3,10 @@
  * and routing decisions.
  *
  * KimiFlare is built around Kimi models served through Cloudflare Workers AI.
- * All seeded models are Workers AI models. AI Gateway is optional — when
- * configured it provides observability, caching, and unified billing for
- * multi-provider setups, but Workers AI models work fine without it via the
- * direct api.cloudflare.com path.
+ * Most seeded models are Workers AI models. AI Gateway is optional for those —
+ * they also work via the direct api.cloudflare.com path. Provider-native models
+ * (e.g. moonshotai/kimi-k3) require AI Gateway and are included so they work out
+ * of the box once a gateway is configured.
  *
  * Routing taxonomy:
  *   - Workers AI chat models go through EITHER:
@@ -25,6 +25,7 @@ export type ModelProvider =
   | "anthropic"
   | "openai"
   | "google"
+  | "moonshotai"
   | "openai-compatible";
 
 export type BillingMode = "unified" | "byok";
@@ -104,6 +105,19 @@ const SEED: ModelEntry[] = [
     supports: { tools: true, reasoning: true, streaming: true, vision: true },
     billingMode: "unified",
   },
+  // ── Kimi K3 (AI Gateway / Moonshot AI, provider-native routing) ──────────
+  {
+    id: "moonshotai/kimi-k3",
+    provider: "moonshotai",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 32_768,
+    // Placeholder pricing — verify against Cloudflare AI Gateway docs once rendered.
+    pricing: { inputPerMtok: 3.0, outputPerMtok: 15.0 },
+    supports: { tools: true, reasoning: true, streaming: true, vision: true },
+    // Cloudflare Unified Billing does not currently cover Moonshot AI.
+    // Use a Moonshot API key (BYOK) via cf-aig-authorization.
+    billingMode: "byok",
+  },
   {
     id: "@cf/moonshotai/kimi-k2.6",
     provider: "workers-ai",
@@ -170,6 +184,7 @@ export function inferProvider(id: string): ModelProvider {
   if (id.startsWith("anthropic/")) return "anthropic";
   if (id.startsWith("openai/")) return "openai";
   if (id.startsWith("google-ai-studio/") || id.startsWith("google/")) return "google";
+  if (id.startsWith("moonshotai/")) return "moonshotai";
   return "openai-compatible";
 }
 

--- a/src/ui/billing-chooser.tsx
+++ b/src/ui/billing-chooser.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 const PROVIDER_NAME: Record<ModelProvider, string> = {
   "workers-ai": "Cloudflare Workers AI",
+  moonshotai: "Moonshot AI",
   anthropic: "Anthropic",
   openai: "OpenAI",
   google: "Google AI Studio",

--- a/src/ui/key-entry-modal.tsx
+++ b/src/ui/key-entry-modal.tsx
@@ -26,6 +26,11 @@ const PROVIDER_INFO: Record<ModelProvider, { name: string; url: string; hint: st
     url: "https://dash.cloudflare.com/profile/api-tokens",
     hint: "Use a token with the Workers AI permission.",
   },
+  moonshotai: {
+    name: "Moonshot AI",
+    url: "https://platform.moonshot.cn/",
+    hint: "Create a key in the Moonshot console. Starts with `sk-`.",
+  },
   anthropic: {
     name: "Anthropic",
     url: "https://console.anthropic.com/settings/keys",
@@ -104,7 +109,7 @@ export function KeyEntryModal({
     }
 
     // 2. Push the secret. Provider type narrowed to keys we know about.
-    const provider = model.provider as "anthropic" | "openai" | "google" | "openai-compatible";
+    const provider = model.provider as "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible";
     const baseName = aliasFor(provider);
     // Append a short random suffix so re-saves don't 409 on existing-name collision.
     const name = `${baseName}-${Math.random().toString(36).slice(2, 8)}`;

--- a/src/ui/model-picker.tsx
+++ b/src/ui/model-picker.tsx
@@ -7,10 +7,13 @@ import { fuzzyFilter } from "../util/fuzzy.js";
 interface Props {
   current: string;
   onPick: (model: ModelEntry | null) => void;
+  /** Optional whitelist of models. When provided, only these models are shown. */
+  models?: ModelEntry[];
 }
 
 const PROVIDER_ORDER: ModelProvider[] = [
   "workers-ai",
+  "moonshotai",
   "anthropic",
   "openai",
   "google",
@@ -19,6 +22,7 @@ const PROVIDER_ORDER: ModelProvider[] = [
 
 const PROVIDER_LABEL: Record<ModelProvider, string> = {
   "workers-ai": "Cloudflare Workers AI",
+  moonshotai: "Moonshot AI",
   anthropic: "Anthropic",
   openai: "OpenAI",
   google: "Google",
@@ -139,13 +143,13 @@ function buildRowsFlat(opts: BuildOpts): Row[] {
   return rows;
 }
 
-export function ModelPicker({ current, onPick }: Props) {
+export function ModelPicker({ current, onPick, models }: Props) {
   const theme = useTheme();
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(0);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const allModels = useMemo(() => listModels(), []);
+  const allModels = useMemo(() => models ?? listModels(), [models]);
   const filtered = useMemo(() => {
     if (!query.trim()) return allModels;
     return fuzzyFilter(allModels, query, (m) => `${m.id} ${m.provider}`);

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -5,8 +5,8 @@ import { ModelPicker } from "./model-picker.js";
 import { BillingChooser, type BillingChoice } from "./billing-chooser.js";
 import { UnifiedBillingStatus } from "./unified-billing-status.js";
 import { KeyEntryModal, type KeyResult } from "./key-entry-modal.js";
-import { isUnifiedEligible, type ModelEntry } from "../models/registry.js";
-import { saveConfig, DEFAULT_MODEL, type KimiConfig } from "../config.js";
+import { isUnifiedEligible, getModel, type ModelEntry } from "../models/registry.js";
+import { saveConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL, type KimiConfig } from "../config.js";
 import { openBrowser } from "./app-helpers.js";
 import { useTheme } from "./theme-context.js";
 import {
@@ -34,6 +34,7 @@ type Step =
   | "gatewayManual"
   | "gatewayProbing"
   | "model"
+  | "cloudModel"
   | "billingChoice"
   | "cloudAuth"
   | "unifiedProbe"
@@ -255,7 +256,8 @@ export function Onboarding({ onDone, onCancel }: Props) {
           setCloudMode(true);
           setAccountId("");
           setApiToken("");
-          setStep("confirm");
+          setModel(DEFAULT_CLOUD_MODEL);
+          setStep("cloudModel");
         })
         .catch((err) => {
           setCloudAuthError(err instanceof Error ? err.message : String(err));
@@ -264,15 +266,19 @@ export function Onboarding({ onDone, onCancel }: Props) {
   };
 
   const handleModelPick = (picked: ModelEntry | null) => {
-    // Esc / cancel in the picker → keep the current default (a Workers AI
-    // model that needs no setup) and skip straight to confirm.
+    // Esc / cancel in the picker → keep the current default and skip straight to confirm.
     if (!picked) {
       setStep("confirm");
       return;
     }
     setModel(picked.id);
     setPickedEntry(picked);
-    // Self-hosted routing (Cloud is chosen up front at the mode step):
+    // Cloud model picker: the user already chose Cloud mode, so just confirm.
+    if (cloudMode) {
+      setStep("confirm");
+      return;
+    }
+    // Self-hosted routing:
     //   workers-ai       → nothing more to set up → confirm
     //   unified-eligible → ask billing mode (Cloudflare credits / BYOK)
     //   BYOK-only        → straight to key entry
@@ -310,7 +316,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
 
   const handleSaveProviderKey = (result: KeyResult) => {
     if (!pickedEntry) return;
-    const provider = pickedEntry.provider as "anthropic" | "openai" | "google" | "openai-compatible";
+    const provider = pickedEntry.provider as "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible";
     if (result.kind === "alias") {
       setProviderKeyAliases((prev) => ({ ...prev, [provider]: result.alias }));
       setSecretsStoreId(result.secretsStoreId);
@@ -352,6 +358,14 @@ export function Onboarding({ onDone, onCancel }: Props) {
       setSavedPath(`error: ${(e as Error).message}`);
     }
   };
+
+  const CLOUD_MODEL_IDS = [
+    "moonshotai/kimi-k3",
+    "@cf/moonshotai/kimi-k2.7-code",
+    "@cf/moonshotai/kimi-k2.6",
+    "@cf/moonshotai/kimi-k2.5",
+  ];
+  const cloudModels = CLOUD_MODEL_IDS.map((id) => getModel(id)).filter((m): m is ModelEntry => !!m);
 
   // Step numbering: keep simple linear count for visible steps.
   const visibleSteps: Step[] = ["mode", "accountId", "apiToken", "routingMode", "model", "confirm"];
@@ -565,6 +579,23 @@ export function Onboarding({ onDone, onCancel }: Props) {
           </>
         )}
 
+        {step === "cloudModel" && (
+          <>
+            <Text>Pick a Kimi model for KimiFlare Cloud</Text>
+            <Text color={theme.info.color} dimColor>
+              K3 runs through Cloudflare AI Gateway; K2.7/2.6/2.5 run on Workers AI.
+            </Text>
+            <Box marginTop={1}>
+              <ModelPicker current={model} onPick={handleModelPick} models={cloudModels} />
+            </Box>
+            <Box marginTop={1}>
+              <Text color={theme.info.color} dimColor>
+                Tip: Esc keeps the default ({DEFAULT_CLOUD_MODEL}) and continues.
+              </Text>
+            </Box>
+          </>
+        )}
+
         {step === "billingChoice" && pickedEntry && (
           <Box marginTop={1}>
             <BillingChooser model={pickedEntry} onPick={handleBillingChoice} />
@@ -660,6 +691,11 @@ export function Onboarding({ onDone, onCancel }: Props) {
                 ) : (
                   <Text color={theme.info.color}>Routing: Workers AI (direct)</Text>
                 ))}
+              {cloudMode && (
+                <Text color={theme.info.color}>
+                  Model: {model}
+                </Text>
+              )}
               {cloudMode && (
                 <Text color={theme.info.color}>
                   Billing: KimiFlare Cloud (free 5M tokens, then $10/mo Pro)

--- a/src/ui/unified-billing-status.tsx
+++ b/src/ui/unified-billing-status.tsx
@@ -8,6 +8,7 @@ import { enableGatewayAuth } from "../cloud/ai-gateway-api.js";
 
 const PROVIDER_NAME: Record<ModelProvider, string> = {
   "workers-ai": "Cloudflare Workers AI",
+  moonshotai: "Moonshot AI",
   anthropic: "Anthropic",
   openai: "OpenAI",
   google: "Google AI Studio",
@@ -142,8 +143,8 @@ export function UnifiedBillingStatus({
           <Box marginTop={1}>
             <Text color={theme.muted?.color ?? theme.info.color} dimColor>
               Credits are one account-wide pool. Confirmed providers: OpenAI &
-              Anthropic. Others (Google, Groq, xAI) may not be supported yet —
-              the retry will tell you.
+              Anthropic. Others (Google, Groq, xAI, Moonshot AI) may not be
+              supported yet — the retry will tell you.
             </Text>
           </Box>
           <Box marginTop={1} flexDirection="column">


### PR DESCRIPTION
## Summary

Adds support for \`moonshotai/kimi-k3\` on Cloudflare AI Gateway. K3 is treated as a provider-native, AI-Gateway-only model and requires a Moonshot API key (BYOK).

## What changed

- **Model registry**
  - Added \`moonshotai\` to \`ModelProvider\`.
  - Seeded \`moonshotai/kimi-k3\` with 1M context, vision/tools/reasoning/streaming, and placeholder \`$3 / $15\` per-1M pricing.
  - Marked K3 as \`billingMode: \"byok\"\` because Cloudflare Unified Billing does not currently cover Moonshot AI.
  - \`inferProvider\` now recognizes \`moonshotai/*\` IDs.

- **Config & credentials**
  - Added \`moonshotai\` to \`providerKeys\` / \`providerKeyAliases\`.
  - Added \`MOONSHOT_API_KEY\` / \`KIMIFLARE_MOONSHOT_KEY\` env support.
  - Changed \`DEFAULT_CLOUD_MODEL\` to \`moonshotai/kimi-k3\`.

- **Agent client**
  - Added Moonshot to \`PROVIDER_DOC\` missing-key guidance.
  - Guarded Unified Billing so it only applies when \`isUnifiedEligible(model)\` is true. This prevents a global \`unifiedBilling=true\` from silently sending unauthenticated requests to BYOK-only providers like Moonshot.

- **UI**
  - Added Moonshot to provider labels/choosers/key-entry hints.
  - Added an optional \`models\` prop to \`ModelPicker\` so cloud onboarding can show a filtered list.
  - Cloud onboarding now shows a model picker with K3, K2.7-code, K2.6, and K2.5 (K3 pre-selected).
  - Updated Unified Billing status copy to reflect that Moonshot is not a confirmed Unified Billing provider.

- **Tests**
  - Added \`src/models/registry.test.ts\` for K3 provider inference and BYOK eligibility.
  - Added Moonshot BYOK header tests in \`src/agent/client.providers.test.ts\`.

## Verification

- \`npm run typecheck\` ✅
- \`npm run build\` ✅
- Relevant tests (\`client.providers.test.ts\`, \`registry.test.ts\`) ✅

## Caveats

- K3 pricing is seeded as a placeholder; verify against Cloudflare AI Gateway docs once rendered.
- \`api.kimiflare.com\` (cloud backend) must also route \`moonshotai/kimi-k3\` through AI Gateway; that change is out of scope for this repo.
- Moonshot AI is **BYOK-only** on Cloudflare AI Gateway today; Unified Billing is not available for it.