### PR TITLE
feat(onboarding): Log in with Cloudflare, hide KimiFlare Cloud, fix Kimi K3 routing

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -55,7 +55,7 @@
 | `src/code-mode/` | TypeScript sandbox for safe tool execution (`runInSandbox`, `generateTypeScriptApi`). |
 | `src/skills/` | Skill routing system: load, select, and inject domain-specific skill files into prompts. |
 | `src/commands/` | Slash command system: builtins, loader, renderer, frontmatter parsing. |
-| `src/cloud/` | Cloudflare AI Gateway management (gateway list/create/show via `api.cloudflare.com`). |
+| `src/cloud/` | Cloudflare account plumbing: AI Gateway management (`ai-gateway-api.ts`), "Log in with Cloudflare" OAuth + PKCE (`cloudflare-oauth.ts`), and the (temporarily hidden, see `availability.ts`) KimiFlare Cloud managed-service client (`auth.ts`, `billing.ts`). |
 | `src/cost-attribution/` | Token cost tracking, heuristic classification, and TUI reporting. |
 | `src/hooks/` | User-configured lifecycle hooks (pre/post tool-call, turn start/end). |
 | `src/models/` | Model registry: capabilities, pricing, and routing decisions per provider. |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## How it works
 
-You bring your own Cloudflare **Account ID** + **API Token**. KimiFlare calls **Workers AI** directly by default — fastest path, fewest moving parts. You can optionally turn on routing through an **AI Gateway** in your account (provisioned or reused on first run) for observability, caching, and cost reporting. Either way, nothing leaves your Cloudflare tenancy.
+KimiFlare runs on **your own Cloudflare account**. On first run you **Log in with Cloudflare** — the CLI opens a browser page, Cloudflare asks you to approve kimiflare once, and you're in (no API token to mint, no Account ID to copy; pasting a token manually still works). KimiFlare calls **Workers AI** directly by default — fastest path, fewest moving parts. You can optionally turn on routing through an **AI Gateway** in your account (provisioned or reused on first run) for observability, caching, and cost reporting. Either way, nothing leaves your Cloudflare tenancy.
 
 With AI Gateway enabled you get this for free:
 
@@ -72,7 +72,7 @@ npm install -g kimiflare
 kimiflare
 ```
 
-On first run, an interactive onboarding wizard collects your Cloudflare credentials and provisions (or picks) an AI Gateway. That's it.
+On first run, an interactive onboarding wizard connects your Cloudflare account — **Log in with Cloudflare** in the browser (recommended) or paste an API token — then provisions (or picks) an AI Gateway. That's it.
 
 Or run without installing:
 
@@ -82,15 +82,17 @@ npx kimiflare
 
 Requires Node.js ≥ 20.
 
-### Cloudflare API token
+### Connecting your Cloudflare account
 
-The onboarding wizard provisions or picks an AI Gateway in your account. Your Cloudflare API token needs:
+**Log in with Cloudflare (recommended).** Pick it in the wizard, or run `kimiflare auth cloudflare` any time. Cloudflare's consent screen shows exactly what kimiflare asks for (Workers AI, AI Gateway, Secrets Store, and read access to your account list so it can pick your Account ID). Tokens are short-lived and refreshed automatically; `/logout` revokes the grant, and you can review it at <https://dash.cloudflare.com/?to=/profile/access-management/authorization>. Details for maintainers (registering the OAuth client) are in [`docs/login-with-cloudflare.md`](docs/login-with-cloudflare.md).
+
+**Or paste an API token.** Create one at https://dash.cloudflare.com/profile/api-tokens with:
 
 - `Workers AI:Read`
 - `AI Gateway:Read` (to list gateways)
 - `AI Gateway:Edit` (to create gateways)
 
-Edit your token at: https://dash.cloudflare.com/profile/api-tokens
+then enter it with your Account ID in the wizard, or set `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` (env credentials override a stored login).
 
 Once configured, `/cost` shows the Gateway-confirmed totals, cache hit ratio, per-feature breakdown, and direct dashboard links to each request log. `/gateway status` shows the current TTL, skip-cache flag, metadata tags, and live cache-hit ratio.
 
@@ -102,6 +104,11 @@ KimiFlare runs on **Kimi K2.7** via Cloudflare Workers AI — no API key needed 
 
 `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.5`, and `@cf/zai-org/glm-5.2`
 (Zhipu AI, 262k context, reasoning + tools) are also available.
+
+**Kimi K3** (`moonshotai/kimi-k3` — 1M context, vision, always-on reasoning) is available as a
+third-party model in Cloudflare's model catalog: pick it with `/model` and it is billed from your
+account's **AI Gateway credits** (Unified Billing) — no Moonshot key needed. Top up credits in the
+AI Gateway dashboard.
 
 ### One-shot mode
 

--- a/docs/login-with-cloudflare.md
+++ b/docs/login-with-cloudflare.md
@@ -1,0 +1,130 @@
+# Log in with Cloudflare
+
+KimiFlare's onboarding no longer asks anyone to open the Cloudflare dashboard,
+mint an API token, tick permission boxes, and paste an Account ID. The first
+option is **Log in with Cloudflare**: the CLI opens a browser page on
+`dash.cloudflare.com`, Cloudflare shows *"kimiflare wants permission to …"*,
+the user clicks **Allow**, and the terminal continues with a scoped token and
+the right account already selected.
+
+Under the hood this is Cloudflare's **self-managed OAuth client** feature
+(GA June 2026 — the same OAuth server `wrangler login` uses):
+
+- <https://developers.cloudflare.com/fundamentals/oauth/>
+- <https://developers.cloudflare.com/fundamentals/oauth/create-an-oauth-client/>
+- <https://developers.cloudflare.com/fundamentals/oauth/integrate-with-cloudflare/>
+- <https://blog.cloudflare.com/oauth-for-all/>
+
+## How the flow works (`src/cloud/cloudflare-oauth.ts`)
+
+1. `loginWithCloudflare()` starts a one-shot loopback HTTP server on
+   `127.0.0.1:8978` and generates a PKCE verifier/challenge + `state`.
+2. It opens
+   `https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=…&redirect_uri=http://localhost:8978/oauth/callback&scope=…&state=…&code_challenge=…&code_challenge_method=S256`.
+3. After the user approves, Cloudflare redirects to the loopback server with
+   `code` + `state`. The CLI exchanges the code at
+   `https://dash.cloudflare.com/oauth2/token` (public client — no secret; PKCE
+   verifier proves possession).
+4. The CLI calls `GET /client/v4/user` and `GET /client/v4/accounts` to show
+   who signed in and to pick the Account ID (auto-selected when the user has
+   one account, otherwise a picker).
+5. `config.json` stores the access token in `apiToken` — so every existing
+   code path keeps working — plus a `cloudflareOAuth` block
+   (`refreshToken`, `expiresAt`, `scopes`, `clientId`, `email`, `accountName`).
+6. Access tokens live ~1 hour. `loadConfig()` refreshes an expiring token on
+   startup (and persists the rotated refresh token); the TUI re-arms a timer
+   before each expiry; `kimiflare serve` refreshes on an interval. `/logout`
+   revokes the refresh token.
+
+Users can review or revoke the grant any time at
+<https://dash.cloudflare.com/?to=/profile/access-management/authorization>.
+
+### Scopes requested
+
+| Scope | Why |
+| --- | --- |
+| `user-details.read` | `GET /user` — show who is signed in |
+| `account-settings.read` | `GET /accounts` — pick the Account ID automatically |
+| `ai.read`, `ai.write` | Workers AI inference; also required by `/accounts/{id}/ai/v1/*` (an AI-Gateway-only token gets `401`) |
+| `aig.read`, `aig.write` | list / create / configure AI Gateways |
+| `aig.run` | run inference through `gateway.ai.cloudflare.com` (authenticated gateways) |
+| `secrets-store.read`, `secrets-store.write` | store provider keys (BYOK aliases) in Secrets Store |
+| `offline_access` | refresh token (added automatically at authorize time) |
+
+Scope ids are Cloudflare's **dot-delimited** OAuth scope ids
+(`GET https://api.cloudflare.com/client/v4/oauth/scopes`). Wrangler's
+colon-delimited `account:read` style is a legacy first-party dialect and is
+rejected for self-managed clients.
+
+## One-time setup: register the `kimiflare` OAuth client
+
+This has to be done once by a maintainer, in the Cloudflare account that will
+own the client (ideally the account that owns `kimiflare.com`, see "Public
+clients" below).
+
+### Option A — dashboard
+
+1. <https://dash.cloudflare.com/?to=/:account/oauth-clients> → **Create client**
+   (needs Super Administrator / Administrator or the *OAuth Client Write* role).
+2. Fill in:
+   - **Client name:** `kimiflare`
+   - **Client URL:** `https://kimiflare.com`
+   - **Logo:** `docs/logo.png`
+   - **Response type:** `code`
+   - **Grant types:** `authorization_code`, `refresh_token`
+   - **Token endpoint authentication method:** `none` (public client, PKCE)
+   - **Redirect URLs:** `http://localhost:8978/oauth/callback`
+     (exact match — `http`, no trailing slash; must equal `CF_OAUTH_REDIRECT_URI`)
+   - **Scopes:** everything in the table above
+3. Copy the **Client ID** (32 hex chars).
+
+### Option B — API
+
+`scripts/register-cf-oauth-client.mjs` does the same via
+`POST /accounts/{id}/oauth_clients`. It needs an API token with
+**Account › OAuth Clients › Write**:
+
+```sh
+CLOUDFLARE_API_TOKEN=… CLOUDFLARE_ACCOUNT_ID=… node scripts/register-cf-oauth-client.mjs
+```
+
+It prints the client id and the exact settings it registered.
+
+### Bake the client id into the CLI
+
+Set `CF_OAUTH_CLIENT_ID` in `src/cloud/cloudflare-oauth.ts` (replace the
+`__KIMIFLARE_CF_OAUTH_CLIENT_ID__` placeholder). Until that is done the
+onboarding pre-selects "Paste an API token" and labels the OAuth option
+"(not configured in this build)"; for local testing you can instead export
+`KIMIFLARE_CF_OAUTH_CLIENT_ID=<client id>`.
+
+Other overrides: `KIMIFLARE_CF_OAUTH_CALLBACK_PORT` (default `8978` — the
+registered redirect URL must match) and `KIMIFLARE_CF_AUTH_DOMAIN`
+(default `dash.cloudflare.com`; `dash.staging.cloudflare.com` for staging).
+
+### Public clients (anyone can log in)
+
+A freshly created client is **private**: only members of the account that owns
+it can authorize it. To let every Cloudflare user log in, promote it to
+**public** in the dashboard. Cloudflare requires a client name, logo, client
+URL, at least one non-identity scope, and **DNS TXT domain verification** on
+the client URL's domain (`cloudflare_oauth_client_publisher=…` on
+`kimiflare.com`; polled for up to two days). Promotion is permanent. Verified
+publishers get a blue shield on the consent screen (unverified apps get amber),
+so it's worth completing.
+
+Account admins can block new public-app authorizations org-wide
+(Manage Account › Members › Settings › *Public OAuth App access*); users in such
+orgs can still use the manual API-token path.
+
+## CLI usage
+
+```sh
+kimiflare                    # onboarding → "Log in with Cloudflare"
+kimiflare auth cloudflare    # headless: sign in / re-sign in, keeps the rest of config.json
+kimiflare auth cloudflare --account <id> --no-browser
+```
+
+Manual tokens keep working: pick **Paste an API token** in onboarding, or set
+`CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` (env credentials override a
+stored OAuth session).

--- a/docs/login-with-cloudflare.md
+++ b/docs/login-with-cloudflare.md
@@ -39,6 +39,14 @@ Under the hood this is Cloudflare's **self-managed OAuth client** feature
 Users can review or revoke the grant any time at
 <https://dash.cloudflare.com/?to=/profile/access-management/authorization>.
 
+One quirk to keep in mind when adding new Cloudflare calls: OAuth access
+tokens work against `api.cloudflare.com` (management API, `/ai/run`,
+`/ai/v1/*` with `cf-aig-gateway-id`) and against the gateway host's
+`/compat` and provider endpoints via `Authorization`, but the gateway host's
+provider-native `…/workers-ai/{model}` route returns 401 for them. Route
+Workers AI calls through `/compat` or the unified `api.cloudflare.com/…/ai`
+endpoints (as `probeGateway()` and the embeddings client do).
+
 ### Scopes requested
 
 | Scope | Why |
@@ -99,9 +107,15 @@ owns `kimiflare.com`:
   `CF_OAUTH_CLIENT_ID` in `src/cloud/cloudflare-oauth.ts`)
 - Public/PKCE client, grants `authorization_code` + `refresh_token`, redirect
   `http://localhost:8978/oauth/callback`, the 9 scopes above (+ `offline_access`)
-- Domain verification TXT record for `kimiflare.com`:
+- Domain verification TXT record on `kimiflare.com` (published, **Verified**):
   `cloudflare_oauth_client_publisher=88913d621ea51f8b2937995a166d4c05`
-  (verification status shows "In progress" until that record is published)
+- Visibility: **Public** (promoted 2026-08-19; any Cloudflare user can log in;
+  the consent screen shows the blue verified-publisher shield)
+- End-to-end verified 2026-08-19: `kimiflare auth cloudflare` → consent →
+  loopback callback → token exchange → `GET /user` + `GET /accounts` →
+  config patched; the resulting token lists gateways (`aig.read`), runs
+  `/compat` inference on the authenticated gateway (`aig.run`), Workers AI
+  direct + K3 via the unified endpoint (`ai.read`), and Secrets Store.
 
 To point a build at a different client (staging, a fork), export
 `KIMIFLARE_CF_OAUTH_CLIENT_ID=<client id>`; if the constant is ever cleared the
@@ -114,9 +128,12 @@ registered redirect URL must match) and `KIMIFLARE_CF_AUTH_DOMAIN`
 
 ### Public clients (anyone can log in)
 
+(The kimiflare client is already public — this is for reference / forks.)
+
 A freshly created client is **private**: only members of the account that owns
 it can authorize it. To let every Cloudflare user log in, promote it to
-**public** in the dashboard. Cloudflare requires a client name, logo, client
+**public** in the dashboard (row menu → *Change Visibility*; *Restart
+Verification* re-polls the TXT record). Cloudflare requires a client name, logo, client
 URL, at least one non-identity scope, and **DNS TXT domain verification** on
 the client URL's domain (for our client: a TXT record on `kimiflare.com` with
 value `cloudflare_oauth_client_publisher=88913d621ea51f8b2937995a166d4c05`;

--- a/docs/login-with-cloudflare.md
+++ b/docs/login-with-cloudflare.md
@@ -90,13 +90,23 @@ CLOUDFLARE_API_TOKEN=… CLOUDFLARE_ACCOUNT_ID=… node scripts/register-cf-oaut
 
 It prints the client id and the exact settings it registered.
 
-### Bake the client id into the CLI
+### Current registration
 
-Set `CF_OAUTH_CLIENT_ID` in `src/cloud/cloudflare-oauth.ts` (replace the
-`__KIMIFLARE_CF_OAUTH_CLIENT_ID__` placeholder). Until that is done the
+The production client is registered (2026-08-19) in the Cloudflare account that
+owns `kimiflare.com`:
+
+- **Client ID:** `2300cf3ff5499cdc69cb52c6b66504b8` (baked into
+  `CF_OAUTH_CLIENT_ID` in `src/cloud/cloudflare-oauth.ts`)
+- Public/PKCE client, grants `authorization_code` + `refresh_token`, redirect
+  `http://localhost:8978/oauth/callback`, the 9 scopes above (+ `offline_access`)
+- Domain verification TXT record for `kimiflare.com`:
+  `cloudflare_oauth_client_publisher=88913d621ea51f8b2937995a166d4c05`
+  (verification status shows "In progress" until that record is published)
+
+To point a build at a different client (staging, a fork), export
+`KIMIFLARE_CF_OAUTH_CLIENT_ID=<client id>`; if the constant is ever cleared the
 onboarding pre-selects "Paste an API token" and labels the OAuth option
-"(not configured in this build)"; for local testing you can instead export
-`KIMIFLARE_CF_OAUTH_CLIENT_ID=<client id>`.
+"(not configured in this build)".
 
 Other overrides: `KIMIFLARE_CF_OAUTH_CALLBACK_PORT` (default `8978` — the
 registered redirect URL must match) and `KIMIFLARE_CF_AUTH_DOMAIN`
@@ -108,8 +118,9 @@ A freshly created client is **private**: only members of the account that owns
 it can authorize it. To let every Cloudflare user log in, promote it to
 **public** in the dashboard. Cloudflare requires a client name, logo, client
 URL, at least one non-identity scope, and **DNS TXT domain verification** on
-the client URL's domain (`cloudflare_oauth_client_publisher=…` on
-`kimiflare.com`; polled for up to two days). Promotion is permanent. Verified
+the client URL's domain (for our client: a TXT record on `kimiflare.com` with
+value `cloudflare_oauth_client_publisher=88913d621ea51f8b2937995a166d4c05`;
+polled for up to two days). Promotion is permanent. Verified
 publishers get a blue shield on the consent screen (unverified apps get amber),
 so it's worth completing.
 

--- a/scripts/register-cf-oauth-client.mjs
+++ b/scripts/register-cf-oauth-client.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * One-time maintainer helper: register the `kimiflare` OAuth client with
+ * Cloudflare via the API (see docs/login-with-cloudflare.md).
+ *
+ *   CLOUDFLARE_API_TOKEN=<token with "OAuth Clients Write"> \
+ *   CLOUDFLARE_ACCOUNT_ID=<account id> \
+ *   node scripts/register-cf-oauth-client.mjs [--name kimiflare] [--port 8978] [--dry-run]
+ *
+ * Prints the resulting client id. Then set CF_OAUTH_CLIENT_ID in
+ * src/cloud/cloudflare-oauth.ts (or export KIMIFLARE_CF_OAUTH_CLIENT_ID).
+ */
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  options: {
+    name: { type: "string", default: "kimiflare" },
+    port: { type: "string", default: "8978" },
+    "client-url": { type: "string", default: "https://kimiflare.com" },
+    "logo-url": { type: "string", default: "https://kimiflare.com/logo.png" },
+    "dry-run": { type: "boolean", default: false },
+  },
+});
+
+const token = process.env.CLOUDFLARE_API_TOKEN;
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+if (!token || !accountId) {
+  console.error("Set CLOUDFLARE_API_TOKEN (OAuth Clients Write) and CLOUDFLARE_ACCOUNT_ID.");
+  process.exit(2);
+}
+
+// Keep in sync with CF_OAUTH_SCOPES / CF_OAUTH_REDIRECT_URI in src/cloud/cloudflare-oauth.ts.
+const scopes = [
+  "user-details.read",
+  "account-settings.read",
+  "ai.read",
+  "ai.write",
+  "aig.read",
+  "aig.write",
+  "aig.run",
+  "secrets-store.read",
+  "secrets-store.write",
+];
+
+const body = {
+  client_name: values.name,
+  client_uri: values["client-url"],
+  logo_uri: values["logo-url"],
+  policy_uri: "https://github.com/sinameraji/kimiflare#readme",
+  tos_uri: "https://github.com/sinameraji/kimiflare/blob/main/LICENSE",
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  token_endpoint_auth_method: "none",
+  redirect_uris: [`http://localhost:${values.port}/oauth/callback`],
+  scopes,
+};
+
+console.log("Registering OAuth client with:\n" + JSON.stringify(body, null, 2));
+if (values["dry-run"]) process.exit(0);
+
+const res = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/oauth_clients`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+const json = await res.json().catch(() => ({}));
+if (!res.ok || !json.success) {
+  console.error(`Failed (HTTP ${res.status}):`, JSON.stringify(json.errors ?? json, null, 2));
+  process.exit(1);
+}
+console.log("\n✓ Created. Client ID:", json.result?.client_id ?? json.result?.id);
+console.log("Visibility:", json.result?.visibility ?? "private");
+if (json.result?.client_uri_verification) {
+  console.log("Domain verification:", JSON.stringify(json.result.client_uri_verification));
+  console.log("→ add that TXT record on the client URL's domain, then promote the client to public in the dashboard.");
+}
+console.log("Next: set CF_OAUTH_CLIENT_ID in src/cloud/cloudflare-oauth.ts (or export KIMIFLARE_CF_OAUTH_CLIENT_ID).");

--- a/src/agent/client.providers.test.ts
+++ b/src/agent/client.providers.test.ts
@@ -222,34 +222,49 @@ describe("runKimi: provider auth-header routing (BYOK alias vs raw key vs unifie
     assert.strictEqual(lastRequest!.headers.get("cf-aig-byok-alias"), null);
   });
 
-  it("Moonshot K3: providerKeys.moonshotai sends cf-aig-authorization", async () => {
+  it("Moonshot K3: routes to Cloudflare's unified REST API with the gateway id header, no provider key", async () => {
+    // Verified live 2026-08-19: moonshotai/kimi-k3 is a Cloudflare-catalog
+    // model paid from AI Gateway credits (Unified Billing). It is reached via
+    // api.cloudflare.com/.../ai/v1/chat/completions, not the gateway host, and
+    // BYOK is not supported on that path — so no cf-aig-authorization / alias
+    // headers even if the user has a Moonshot key lying around.
     for await (const _ of runKimi({
       ...baseOpts,
       model: "moonshotai/kimi-k3",
       providerKeys: { moonshotai: "sk-moonshot-test" },
+      gateway: { id: "gw", cacheTtl: 60 },
     })) {
       /* drain */
     }
     assert.strictEqual(
-      lastRequest!.headers.get("cf-aig-authorization"),
-      "Bearer sk-moonshot-test",
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/chat/completions",
     );
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer cf-token");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-gateway-id"), "gw");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-cache-ttl"), "60");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-authorization"), null);
     assert.strictEqual(lastRequest!.headers.get("cf-aig-byok-alias"), null);
+    const body = JSON.parse(await lastRequest!.text()) as Record<string, unknown>;
+    assert.strictEqual(body.model, "moonshotai/kimi-k3");
+    // K3 fixes temperature=1.0 and 400s on anything else — must be omitted.
+    assert.strictEqual("temperature" in body, false);
+    assert.deepStrictEqual(body.stream_options, { include_usage: true });
   });
 
-  it("Moonshot K3: unifiedBilling=true is ignored because provider is BYOK-only", async () => {
-    await assert.rejects(
-      async () => {
-        for await (const _ of runKimi({
-          ...baseOpts,
-          model: "moonshotai/kimi-k3",
-          unifiedBilling: true,
-        })) {
-          /* drain */
-        }
-      },
-      (err: Error) => err.message.includes("needs a Moonshot AI API key"),
+  it("Moonshot K3: works without a configured gateway (Cloudflare uses the default gateway)", async () => {
+    for await (const _ of runKimi({
+      ...baseOpts,
+      model: "moonshotai/kimi-k3",
+      gateway: undefined,
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/chat/completions",
     );
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-gateway-id"), null);
   });
 });
 

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -12,7 +12,7 @@ import {
   type LlmDumpRecord,
   type LlmDumpResponse,
 } from "../util/llm-dump.js";
-import { getModelOrInfer, isUnifiedEligible, type ModelProvider } from "../models/registry.js";
+import { getModelOrInfer, isUnifiedEligible, routeFor, type ModelProvider } from "../models/registry.js";
 import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
 
 export type KimiEvent =
@@ -111,7 +111,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   // (e.g. "workers-ai/@cf/moonshotai/kimi-k2.7-code"). Cloud mode uses its own
   // shape and ignores this field. The direct Workers AI path (api.cloudflare.com)
   // also ignores the body model field because the model is already in the URL.
-  const isDirectWorkersAi = url.startsWith("https://api.cloudflare.com/client/v4/accounts/");
+  const isDirectWorkersAi = url.includes("/ai/run/");
   const compatModel = entry.provider === "workers-ai" ? `workers-ai/${opts.model}` : opts.model;
 
   const body: Record<string, unknown> = {
@@ -404,6 +404,24 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
   }
 
   const entry = getModelOrInfer(opts.model);
+
+  // Cloudflare-catalog models (Kimi K3 today): Cloudflare's unified REST API.
+  // Same OpenAI-shaped request/stream as the gateway path, but auth is only
+  // the Cloudflare token — Cloudflare pays the provider from the account's AI
+  // Gateway credits (Unified Billing). The gateway is optional: with
+  // `cf-aig-gateway-id` set the request is logged in that gateway, otherwise
+  // Cloudflare uses (and auto-creates) the "default" gateway. cf-aig-* headers
+  // (cache TTL, skip-cache, metadata, collect-log) apply here too.
+  if (routeFor(entry) === "cf-catalog") {
+    const headers = gatewayHeadersFor(opts);
+    if (opts.gateway?.id) headers["cf-aig-gateway-id"] = opts.gateway.id;
+    return {
+      url: `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(
+        opts.accountId,
+      )}/ai/v1/chat/completions`,
+      headers,
+    };
+  }
 
   // If no gateway is configured, Workers AI models can use the direct
   // api.cloudflare.com path for lower latency. Non-Workers-AI models still

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,6 +56,7 @@ import {
   DEFAULT_REASONING_EFFORT,
   loadConfig,
   saveConfig,
+  refreshCloudflareSession,
   type ReasoningEffort,
 } from "./config.js";
 import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client.js";
@@ -151,6 +152,8 @@ export interface Cfg {
   accountId: string;
   apiToken: string;
   model: string;
+  /** Set when apiToken is a "Log in with Cloudflare" OAuth access token (see config.ts). */
+  cloudflareOAuth?: import("./config.js").CloudflareOAuthConfig;
   aiGatewayId?: string;
   aiGatewayCacheTtl?: number;
   aiGatewaySkipCache?: boolean;
@@ -439,6 +442,31 @@ function App({
     });
     return () => { cancelled = true; };
   }, []);
+
+  // "Log in with Cloudflare" sessions carry a short-lived access token. Keep
+  // it fresh for the lifetime of the TUI: schedule a refresh a few minutes
+  // before expiry (refreshCloudflareSession() is a no-op until then), swap the
+  // new token into cfg, and re-arm for the next expiry. Turns already in
+  // flight keep the token they started with.
+  useEffect(() => {
+    const oauth = cfg?.cloudflareOAuth;
+    if (!cfg || !oauth?.refreshToken) return;
+    let cancelled = false;
+    const REFRESH_LEAD_MS = 5 * 60 * 1000;
+    const delay = Math.max(1_000, oauth.expiresAt - Date.now() - REFRESH_LEAD_MS + 500);
+    const timer = setTimeout(() => {
+      void refreshCloudflareSession(cfg).then((next) => {
+        if (cancelled || !next) return;
+        setCfg((prev) =>
+          prev ? { ...prev, apiToken: next.apiToken, cloudflareOAuth: next.cloudflareOAuth } : prev,
+        );
+      });
+    }, delay);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [cfg?.cloudflareOAuth?.expiresAt, cfg?.cloudflareOAuth?.refreshToken]);
 
   // Fetch cloud token budget on startup
   useEffect(() => {

--- a/src/cloud/ai-gateway-api.test.ts
+++ b/src/cloud/ai-gateway-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { listGateways, createGateway, AiGatewayError } from "./ai-gateway-api.js";
+import { listGateways, createGateway, probeGateway, AiGatewayError } from "./ai-gateway-api.js";
 
 describe("ai-gateway-api", () => {
   let originalFetch: typeof globalThis.fetch;
@@ -61,5 +61,29 @@ describe("ai-gateway-api", () => {
     assert.strictEqual(body.id, "kimiflare");
     assert.strictEqual(body.cache_ttl, 0);
     assert.strictEqual(body.collect_logs, true);
+  });
+
+  it("probeGateway routes through the unified AI endpoint with cf-aig-gateway-id (works with OAuth tokens)", async () => {
+    nextResponse = { status: 200, body: { result: { data: [[0.1]] }, success: true } };
+    const r = await probeGateway("acct", "cfoat_token", "kimiflare");
+    assert.deepStrictEqual(r, { ok: true });
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/baai/bge-base-en-v1.5",
+    );
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-gateway-id"), "kimiflare");
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer cfoat_token");
+  });
+
+  it("probeGateway reports a missing gateway (HTTP 400 code 2001) and auth failures", async () => {
+    nextResponse = { status: 400, body: { success: false, errors: [{ code: 2001, message: "Please configure AI Gateway in the Cloudflare dashboard" }] } };
+    const missing = await probeGateway("acct", "tok", "nope");
+    assert.strictEqual(missing.ok, false);
+    assert.match((missing as { message: string }).message, /"nope" was not found/);
+
+    nextResponse = { status: 401, body: { success: false, errors: [{ code: 10000, message: "Authentication error" }] } };
+    const denied = await probeGateway("acct", "tok", "kimiflare");
+    assert.strictEqual(denied.ok, false);
+    assert.match((denied as { message: string }).message, /Authentication error \(HTTP 401\)/);
   });
 });

--- a/src/cloud/ai-gateway-api.ts
+++ b/src/cloud/ai-gateway-api.ts
@@ -155,16 +155,23 @@ export async function enableGatewayAuth(
 
 /**
  * Validate that the gateway is reachable for a Workers AI request. We send a
- * minimal request to a known-cheap embeddings model and treat any 2xx/4xx
- * response from Cloudflare as proof that routing works; only network errors
- * and 5xx are surfaced as probe failures.
+ * minimal request to a known-cheap embeddings model through Cloudflare's
+ * unified AI REST endpoint with `cf-aig-gateway-id`, which is exactly how the
+ * app routes Workers AI + catalog models through the gateway. A 2xx proves the
+ * token can run Workers AI and the gateway id resolves; a non-existent gateway
+ * comes back as HTTP 400 code 2001 ("Please configure AI Gateway"), and a
+ * token without Workers AI permission as 401.
+ *
+ * (The provider-native gateway.ai.cloudflare.com/…/workers-ai/{model} path
+ * used previously rejects "Log in with Cloudflare" OAuth access tokens with a
+ * 401 even when they carry aig.run + ai.read, so it is not used here.)
  */
 export async function probeGateway(
   accountId: string,
   apiToken: string,
   gatewayId: string,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
-  const url = `https://gateway.ai.cloudflare.com/v1/${encodeURIComponent(accountId)}/${encodeURIComponent(gatewayId)}/workers-ai/@cf/baai/bge-base-en-v1.5`;
+  const url = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai/run/@cf/baai/bge-base-en-v1.5`;
   try {
     const res = await fetch(url, {
       method: "POST",
@@ -172,14 +179,17 @@ export async function probeGateway(
         Authorization: `Bearer ${apiToken}`,
         "Content-Type": "application/json",
         "User-Agent": getUserAgent(),
+        "cf-aig-gateway-id": gatewayId,
         "cf-aig-skip-cache": "true",
       },
       body: JSON.stringify({ text: ["kimiflare probe"] }),
     });
-    if (res.status >= 500) {
-      return { ok: false, message: `Gateway returned HTTP ${res.status}` };
+    if (res.ok) return { ok: true };
+    const err = await parseCloudflareError(res);
+    if (res.status === 400 && /configure AI Gateway/i.test(err.message)) {
+      return { ok: false, message: `Gateway "${gatewayId}" was not found in this account` };
     }
-    return { ok: true };
+    return { ok: false, message: `${err.message} (HTTP ${res.status})` };
   } catch (e) {
     return { ok: false, message: e instanceof Error ? e.message : String(e) };
   }

--- a/src/cloud/availability.test.tsx
+++ b/src/cloud/availability.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * KimiFlare Cloud is temporarily hidden. These tests pin the user-journey
+ * guarantees: no Cloud option in onboarding or the billing chooser, and no
+ * way for a persisted/env cloudMode to put the user on the managed service.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import React from "react";
+import { renderToString } from "ink";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isCloudModeAvailable, CLOUD_UNAVAILABLE_NOTICE } from "./availability.js";
+import { Onboarding } from "../ui/onboarding.js";
+import { BillingChooser } from "../ui/billing-chooser.js";
+import { ThemeProvider } from "../ui/theme-context.js";
+import { resolveTheme } from "../ui/theme.js";
+import { getModel } from "../models/registry.js";
+import { loadConfig } from "../config.js";
+
+const theme = resolveTheme();
+
+describe("KimiFlare Cloud is hidden (BYOK-only)", () => {
+  it("the gate is off and the notice points at Log in with Cloudflare", () => {
+    assert.strictEqual(isCloudModeAvailable(), false);
+    assert.match(CLOUD_UNAVAILABLE_NOTICE, /Log in with Cloudflare/);
+  });
+
+  it("onboarding starts at 'Connect your Cloudflare account' and never offers KimiFlare Cloud", () => {
+    const out = renderToString(
+      <ThemeProvider theme={theme}>
+        <Onboarding onDone={() => {}} />
+      </ThemeProvider>,
+    );
+    assert.match(out, /Connect your Cloudflare account/);
+    assert.match(out, /Log in with Cloudflare/);
+    assert.match(out, /Paste an API token/);
+    assert.doesNotMatch(out, /KimiFlare Cloud/i);
+    assert.doesNotMatch(out, /5,000,000 tokens free/);
+    assert.match(out, /Step 1 of 4/);
+  });
+
+  it("the billing chooser no longer offers 'Start free with Kimiflare Cloud'", () => {
+    const model = getModel("@cf/moonshotai/kimi-k2.6")!;
+    const out = renderToString(
+      <ThemeProvider theme={theme}>
+        <BillingChooser model={model} onPick={() => {}} />
+      </ThemeProvider>,
+    );
+    assert.doesNotMatch(out, /Kimiflare Cloud/i);
+    assert.match(out, /Use Cloudflare credits/);
+  });
+
+  it("a persisted cloudMode:true config with no BYOK creds is ignored → onboarding (loadConfig returns null)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-cloudgate-"));
+    const prev = { xdg: process.env.XDG_CONFIG_HOME, cloud: process.env.KIMIFLARE_CLOUD, acct: process.env.CLOUDFLARE_ACCOUNT_ID, tok: process.env.CLOUDFLARE_API_TOKEN };
+    try {
+      process.env.XDG_CONFIG_HOME = dir;
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      delete process.env.CLOUDFLARE_API_TOKEN;
+      delete process.env.CF_ACCOUNT_ID;
+      delete process.env.CF_API_TOKEN;
+      await mkdir(join(dir, "kimiflare"), { recursive: true });
+      await writeFile(join(dir, "kimiflare", "config.json"), JSON.stringify({ accountId: "", apiToken: "", model: "moonshotai/kimi-k3", cloudMode: true }));
+      assert.strictEqual(await loadConfig(), null);
+
+      // KIMIFLARE_CLOUD=1 is ignored as well.
+      process.env.KIMIFLARE_CLOUD = "1";
+      assert.strictEqual(await loadConfig(), null);
+
+      // A BYOK config that also carries cloudMode:true loads as plain BYOK.
+      await writeFile(join(dir, "kimiflare", "config.json"), JSON.stringify({ accountId: "acct", apiToken: "tok", model: "@cf/moonshotai/kimi-k2.6", cloudMode: true }));
+      const cfg = await loadConfig();
+      assert.ok(cfg);
+      assert.strictEqual(cfg.cloudMode, undefined);
+      assert.strictEqual(cfg.accountId, "acct");
+    } finally {
+      if (prev.xdg === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prev.xdg;
+      if (prev.cloud === undefined) delete process.env.KIMIFLARE_CLOUD; else process.env.KIMIFLARE_CLOUD = prev.cloud;
+      if (prev.acct !== undefined) process.env.CLOUDFLARE_ACCOUNT_ID = prev.acct;
+      if (prev.tok !== undefined) process.env.CLOUDFLARE_API_TOKEN = prev.tok;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cloud/availability.ts
+++ b/src/cloud/availability.ts
@@ -1,0 +1,31 @@
+/**
+ * KimiFlare Cloud (managed service) availability gate.
+ *
+ * The managed KimiFlare Cloud path — device-code sign-in against
+ * api.kimiflare.com, the free-token grant, Stripe upgrade/top-up, and the
+ * `--cloud` / `kimiflare auth cloud` entry points — is TEMPORARILY HIDDEN.
+ * KimiFlare is BYOK-only for now: users connect their own Cloudflare account
+ * (Log in with Cloudflare, or a manually pasted API token).
+ *
+ * Nothing under src/cloud/ is deleted; every user-facing entry point simply
+ * consults `isCloudModeAvailable()` and, when it returns false:
+ *   - the onboarding wizard does not offer "KimiFlare Cloud",
+ *   - `--cloud`, `KIMIFLARE_CLOUD=1`, and a persisted `cloudMode: true` are
+ *     ignored (the user is routed to BYOK onboarding instead),
+ *   - `kimiflare auth cloud` / `kimiflare usage` print a short notice,
+ *   - the /upgrade, /topup and /manage slash commands print a short notice.
+ *
+ * To bring the managed service back, flip CLOUD_MODE_ENABLED to true. Keep
+ * the flag as a plain constant (not an env var) so there is genuinely no
+ * path through the managed service while it is switched off.
+ */
+export const CLOUD_MODE_ENABLED = false;
+
+export function isCloudModeAvailable(): boolean {
+  return CLOUD_MODE_ENABLED;
+}
+
+/** One-line notice shown wherever a hidden Cloud entry point is hit. */
+export const CLOUD_UNAVAILABLE_NOTICE =
+  "KimiFlare Cloud is temporarily unavailable. KimiFlare now runs on your own Cloudflare account — " +
+  "run `kimiflare` and pick “Log in with Cloudflare” to connect it.";

--- a/src/cloud/cloudflare-oauth.test.ts
+++ b/src/cloud/cloudflare-oauth.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { createHash } from "node:crypto";
+import { createServer } from "node:net";
+import {
+  generatePkce,
+  buildAuthorizeUrl,
+  tokenNeedsRefresh,
+  loginWithCloudflare,
+  refreshCloudflareToken,
+  isCloudflareLoginConfigured,
+  CloudflareOAuthError,
+  CF_OAUTH_AUTH_URL,
+  CF_OAUTH_TOKEN_URL,
+  CF_OAUTH_SCOPES,
+} from "./cloudflare-oauth.js";
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as { port: number }).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+describe("cloudflare-oauth: PKCE + authorize URL", () => {
+  it("generates a 96-char verifier from the PKCE charset and an S256 challenge", () => {
+    const { verifier, challenge } = generatePkce();
+    assert.strictEqual(verifier.length, 96);
+    assert.match(verifier, /^[A-Za-z0-9\-._~]+$/);
+    assert.strictEqual(challenge, base64url(createHash("sha256").update(verifier).digest()));
+  });
+
+  it("builds a dash.cloudflare.com authorize URL with PKCE, state and offline_access", () => {
+    const url = new URL(
+      buildAuthorizeUrl({ clientId: "abc123", state: "st4te", codeChallenge: "ch4llenge", redirectUri: "http://localhost:1234/oauth/callback" }),
+    );
+    assert.strictEqual(`${url.origin}${url.pathname}`, CF_OAUTH_AUTH_URL);
+    assert.strictEqual(url.searchParams.get("response_type"), "code");
+    assert.strictEqual(url.searchParams.get("client_id"), "abc123");
+    assert.strictEqual(url.searchParams.get("redirect_uri"), "http://localhost:1234/oauth/callback");
+    assert.strictEqual(url.searchParams.get("state"), "st4te");
+    assert.strictEqual(url.searchParams.get("code_challenge"), "ch4llenge");
+    assert.strictEqual(url.searchParams.get("code_challenge_method"), "S256");
+    const scopes = url.searchParams.get("scope")!.split(" ");
+    for (const s of CF_OAUTH_SCOPES) assert.ok(scopes.includes(s), `missing scope ${s}`);
+    assert.ok(scopes.includes("offline_access"));
+    // Cloudflare's self-managed clients only accept dot-delimited scope ids.
+    for (const s of scopes) assert.ok(!s.includes(":"), `legacy colon scope leaked: ${s}`);
+  });
+
+  it("asks for the AI Gateway + Workers AI + account scopes kimiflare needs", () => {
+    for (const s of ["account-settings.read", "user-details.read", "ai.read", "aig.read", "aig.write", "aig.run"]) {
+      assert.ok(CF_OAUTH_SCOPES.includes(s), `expected scope ${s}`);
+    }
+  });
+
+  it("tokenNeedsRefresh honours the skew window", () => {
+    const now = 1_000_000;
+    assert.strictEqual(tokenNeedsRefresh(now + 10 * 60_000, now, 5 * 60_000), false);
+    assert.strictEqual(tokenNeedsRefresh(now + 4 * 60_000, now, 5 * 60_000), true);
+    assert.strictEqual(tokenNeedsRefresh(now - 1, now, 5 * 60_000), true);
+  });
+
+  it("isCloudflareLoginConfigured rejects the placeholder client id", () => {
+    assert.strictEqual(isCloudflareLoginConfigured("__KIMIFLARE_CF_OAUTH_CLIENT_ID__"), false);
+    assert.strictEqual(isCloudflareLoginConfigured(""), false);
+    assert.strictEqual(isCloudflareLoginConfigured("223a6ddec4aad6a652bf9b5ce840912c"), true);
+  });
+});
+
+describe("cloudflare-oauth: loopback login flow", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let tokenRequests: URLSearchParams[] = [];
+  let tokenResponse: () => Response = () =>
+    new Response(
+      JSON.stringify({ access_token: "cfoat_test", refresh_token: "cfort_test", expires_in: 3600, scope: "aig.read ai.read offline_access", token_type: "bearer" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === CF_OAUTH_TOKEN_URL) {
+        tokenRequests.push(new URLSearchParams(String(init?.body ?? "")));
+        return tokenResponse();
+      }
+      return originalFetch(input, init);
+    };
+  });
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("opens the browser URL, receives the callback, exchanges the code with PKCE, and resolves tokens", async () => {
+    tokenRequests = [];
+    const port = await freePort();
+    let authUrl = "";
+    const login = loginWithCloudflare({
+      clientId: "clientid123",
+      port,
+      timeoutMs: 10_000,
+      onAuthUrl: (u) => {
+        authUrl = u;
+      },
+    });
+    // Give the server a tick to start and hand us the URL.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(authUrl.startsWith(CF_OAUTH_AUTH_URL), "auth URL should point at dash.cloudflare.com");
+    const parsed = new URL(authUrl);
+    const state = parsed.searchParams.get("state")!;
+    const redirect = parsed.searchParams.get("redirect_uri")!;
+    assert.strictEqual(redirect, `http://localhost:${port}/oauth/callback`);
+
+    // Simulate the browser redirect back to the loopback server.
+    const cb = await originalFetch(`http://127.0.0.1:${port}/oauth/callback?code=AUTHCODE&state=${encodeURIComponent(state)}`);
+    assert.strictEqual(cb.status, 200);
+    assert.match(await cb.text(), /Signed in to kimiflare/);
+
+    const tokens = await login;
+    assert.strictEqual(tokens.accessToken, "cfoat_test");
+    assert.strictEqual(tokens.refreshToken, "cfort_test");
+    assert.deepStrictEqual(tokens.scopes, ["aig.read", "ai.read", "offline_access"]);
+    assert.ok(tokens.expiresAt > Date.now() + 3000_000);
+
+    assert.strictEqual(tokenRequests.length, 1);
+    const body = tokenRequests[0]!;
+    assert.strictEqual(body.get("grant_type"), "authorization_code");
+    assert.strictEqual(body.get("code"), "AUTHCODE");
+    assert.strictEqual(body.get("client_id"), "clientid123");
+    assert.strictEqual(body.get("redirect_uri"), redirect);
+    const verifier = body.get("code_verifier")!;
+    assert.strictEqual(base64url(createHash("sha256").update(verifier).digest()), parsed.searchParams.get("code_challenge"));
+    // Public client: no client_secret ever leaves the CLI.
+    assert.strictEqual(body.get("client_secret"), null);
+  });
+
+  it("rejects a callback whose state does not match (CSRF guard)", async () => {
+    const port = await freePort();
+    const login = loginWithCloudflare({ clientId: "clientid123", port, timeoutMs: 10_000, onAuthUrl: () => {} });
+    const expectation = assert.rejects(login, (e: CloudflareOAuthError) => e.code === "invalid_callback");
+    await new Promise((r) => setTimeout(r, 50));
+    const cb = await originalFetch(`http://127.0.0.1:${port}/oauth/callback?code=AUTHCODE&state=WRONG`);
+    assert.strictEqual(cb.status, 400);
+    await expectation;
+  });
+
+  it("surfaces an OAuth error redirect (user clicked Deny)", async () => {
+    const port = await freePort();
+    const login = loginWithCloudflare({ clientId: "clientid123", port, timeoutMs: 10_000, onAuthUrl: () => {} });
+    const expectation = assert.rejects(login, (e: CloudflareOAuthError) => e.code === "access_denied" && /user denied/.test(e.message));
+    await new Promise((r) => setTimeout(r, 50));
+    await originalFetch(`http://127.0.0.1:${port}/oauth/callback?error=access_denied&error_description=user+denied`);
+    await expectation;
+  });
+
+  it("aborts cleanly via AbortSignal", async () => {
+    const port = await freePort();
+    const ac = new AbortController();
+    const login = loginWithCloudflare({ clientId: "clientid123", port, timeoutMs: 10_000, signal: ac.signal, onAuthUrl: () => {} });
+    const expectation = assert.rejects(login, (e: CloudflareOAuthError) => e.code === "aborted");
+    await new Promise((r) => setTimeout(r, 50));
+    ac.abort();
+    await expectation;
+  });
+
+  it("refuses to start without a configured client id", async () => {
+    await assert.rejects(
+      loginWithCloudflare({ clientId: "__KIMIFLARE_CF_OAUTH_CLIENT_ID__", onAuthUrl: () => {} }),
+      (e: CloudflareOAuthError) => e.code === "not_configured",
+    );
+  });
+
+  it("refreshCloudflareToken posts grant_type=refresh_token and keeps the old refresh token if none is returned", async () => {
+    tokenRequests = [];
+    const prev = tokenResponse;
+    tokenResponse = () =>
+      new Response(JSON.stringify({ access_token: "cfoat_new", expires_in: 3600, scope: "aig.read" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const fresh = await refreshCloudflareToken("cfort_old", "clientid123");
+      assert.strictEqual(fresh.accessToken, "cfoat_new");
+      assert.strictEqual(fresh.refreshToken, "cfort_old");
+      const body = tokenRequests[0]!;
+      assert.strictEqual(body.get("grant_type"), "refresh_token");
+      assert.strictEqual(body.get("refresh_token"), "cfort_old");
+      assert.strictEqual(body.get("client_id"), "clientid123");
+    } finally {
+      tokenResponse = prev;
+    }
+  });
+
+  it("turns token-endpoint errors into CloudflareOAuthError with the OAuth code", async () => {
+    const prev = tokenResponse;
+    tokenResponse = () =>
+      new Response(JSON.stringify({ error: "invalid_grant", error_description: "refresh token expired" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      await assert.rejects(
+        refreshCloudflareToken("cfort_dead", "clientid123"),
+        (e: CloudflareOAuthError) => e.code === "invalid_grant" && /refresh token expired/.test(e.message),
+      );
+    } finally {
+      tokenResponse = prev;
+    }
+  });
+});

--- a/src/cloud/cloudflare-oauth.ts
+++ b/src/cloud/cloudflare-oauth.ts
@@ -40,12 +40,13 @@ export const CF_OAUTH_TOKEN_URL = `https://${AUTH_DOMAIN}/oauth2/token`;
 export const CF_OAUTH_REVOKE_URL = `https://${AUTH_DOMAIN}/oauth2/revoke`;
 
 /**
- * kimiflare's OAuth client id, registered with Cloudflare ("Log in with
- * Cloudflare"). Override with KIMIFLARE_CF_OAUTH_CLIENT_ID for staging /
- * self-registered clients.
+ * kimiflare's OAuth client id — a Cloudflare self-managed OAuth client
+ * ("kimiflare", public/PKCE, registered 2026-08-19 in the account that owns
+ * kimiflare.com; see docs/login-with-cloudflare.md). Override with
+ * KIMIFLARE_CF_OAUTH_CLIENT_ID for staging / self-registered clients.
  */
 export const CF_OAUTH_CLIENT_ID =
-  process.env.KIMIFLARE_CF_OAUTH_CLIENT_ID ?? "__KIMIFLARE_CF_OAUTH_CLIENT_ID__";
+  process.env.KIMIFLARE_CF_OAUTH_CLIENT_ID ?? "2300cf3ff5499cdc69cb52c6b66504b8";
 
 /** True once a real OAuth client id is baked in (or provided via env). */
 export function isCloudflareLoginConfigured(clientId: string = CF_OAUTH_CLIENT_ID): boolean {

--- a/src/cloud/cloudflare-oauth.ts
+++ b/src/cloud/cloudflare-oauth.ts
@@ -1,0 +1,421 @@
+/**
+ * Log in with Cloudflare — OAuth 2.0 authorization-code flow with PKCE.
+ *
+ * This is the "beautiful" onboarding path: instead of asking the user to open
+ * the Cloudflare dashboard, mint an API token, pick permissions, and paste both
+ * the token and their Account ID into the terminal, we
+ *
+ *   1. start a one-shot loopback HTTP server on 127.0.0.1,
+ *   2. open https://dash.cloudflare.com/oauth2/auth in the browser with our
+ *      client id + PKCE challenge + the scopes kimiflare needs,
+ *   3. Cloudflare shows the user "kimiflare wants permission to …" and, once
+ *      they approve, redirects to the loopback server with an auth code,
+ *   4. we exchange the code (+ PKCE verifier) for an access token and a
+ *      refresh token, then look up the user's account(s) via the API.
+ *
+ * The access token is a regular Cloudflare API bearer token: it works against
+ * api.cloudflare.com (AI Gateway management, Workers AI, Secrets Store) and
+ * gateway.ai.cloudflare.com (the gateway-level `Authorization` header). It is
+ * short-lived, so `refreshCloudflareToken()` / `ensureFreshCloudflareToken()`
+ * rotate it in the background using the refresh token (`offline_access`).
+ *
+ * The protocol is the same one `wrangler login` speaks (see
+ * cloudflare/workers-sdk packages/wrangler/src/user/user.ts). kimiflare uses
+ * its own OAuth client id — never wrangler's.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { randomBytes, createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import { getUserAgent } from "../util/version.js";
+import { logger } from "../util/logger.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AUTH_DOMAIN = process.env.KIMIFLARE_CF_AUTH_DOMAIN ?? "dash.cloudflare.com";
+export const CF_OAUTH_AUTH_URL = `https://${AUTH_DOMAIN}/oauth2/auth`;
+export const CF_OAUTH_TOKEN_URL = `https://${AUTH_DOMAIN}/oauth2/token`;
+export const CF_OAUTH_REVOKE_URL = `https://${AUTH_DOMAIN}/oauth2/revoke`;
+
+/**
+ * kimiflare's OAuth client id, registered with Cloudflare ("Log in with
+ * Cloudflare"). Override with KIMIFLARE_CF_OAUTH_CLIENT_ID for staging /
+ * self-registered clients.
+ */
+export const CF_OAUTH_CLIENT_ID =
+  process.env.KIMIFLARE_CF_OAUTH_CLIENT_ID ?? "__KIMIFLARE_CF_OAUTH_CLIENT_ID__";
+
+/** True once a real OAuth client id is baked in (or provided via env). */
+export function isCloudflareLoginConfigured(clientId: string = CF_OAUTH_CLIENT_ID): boolean {
+  return !!clientId && !clientId.startsWith("__");
+}
+
+/**
+ * Loopback redirect. The path/port must match what is registered for the
+ * OAuth client. Port 0 is not allowed by Cloudflare's redirect matching, so we
+ * bind a fixed port and fail loudly if it is taken.
+ */
+export const CF_OAUTH_CALLBACK_PORT = Number(process.env.KIMIFLARE_CF_OAUTH_CALLBACK_PORT ?? 8978);
+export const CF_OAUTH_CALLBACK_PATH = "/oauth/callback";
+export const CF_OAUTH_REDIRECT_URI = `http://localhost:${CF_OAUTH_CALLBACK_PORT}${CF_OAUTH_CALLBACK_PATH}`;
+
+/**
+ * Scopes kimiflare asks for. Keep this list tight — it is exactly what the
+ * user sees on the consent screen. Names are Cloudflare's dot-delimited OAuth
+ * scope ids (GET https://api.cloudflare.com/client/v4/oauth/scopes); the
+ * colon-delimited `account:read` style is wrangler's legacy first-party
+ * dialect and is rejected for self-managed clients.
+ *
+ *   user-details.read      GET /user  → show who is signed in
+ *   account-settings.read  GET /accounts → pick the Account ID automatically
+ *   ai.read / ai.write     Workers AI (also required by /accounts/{id}/ai/v1/*
+ *                          — an AI-Gateway-only token gets 401 there)
+ *   aig.read / aig.write   list / create / configure AI Gateways
+ *   aig.run                run inference through gateway.ai.cloudflare.com
+ *   secrets-store.read/write  store provider keys (BYOK aliases) in Secrets Store
+ *
+ * `offline_access` is appended at authorize time so we get a refresh token.
+ * The registered client must allow every scope requested here.
+ */
+export const CF_OAUTH_SCOPES: readonly string[] = [
+  "user-details.read",
+  "account-settings.read",
+  "ai.read",
+  "ai.write",
+  "aig.read",
+  "aig.write",
+  "aig.run",
+  "secrets-store.read",
+  "secrets-store.write",
+];
+
+/** How long before expiry we proactively refresh. */
+export const REFRESH_SKEW_MS = 5 * 60 * 1000;
+/** How long we wait for the user to finish in the browser. */
+export const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CloudflareOAuthTokens {
+  accessToken: string;
+  /** Present when `offline_access` was granted. Rotates on every refresh. */
+  refreshToken?: string;
+  /** Epoch milliseconds. */
+  expiresAt: number;
+  scopes: string[];
+}
+
+/** What we persist in config.json next to `apiToken` (which mirrors accessToken). */
+export interface CloudflareOAuthState {
+  refreshToken?: string;
+  expiresAt: number;
+  scopes: string[];
+  clientId: string;
+}
+
+export interface CloudflareAccount {
+  id: string;
+  name: string;
+}
+
+export class CloudflareOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+    public readonly description?: string,
+  ) {
+    super(message);
+    this.name = "CloudflareOAuthError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PKCE helpers (RFC 7636)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PKCE_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Random string drawn from the PKCE charset. Exported for tests. */
+export function randomFromCharset(length: number, charset = PKCE_CHARSET): string {
+  const bytes = randomBytes(length);
+  let out = "";
+  for (let i = 0; i < length; i++) out += charset[bytes[i]! % charset.length];
+  return out;
+}
+
+export function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = randomFromCharset(96);
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+export function buildAuthorizeUrl(params: {
+  clientId?: string;
+  redirectUri?: string;
+  scopes?: readonly string[];
+  state: string;
+  codeChallenge: string;
+}): string {
+  const scopes = [...(params.scopes ?? CF_OAUTH_SCOPES), "offline_access"];
+  const q = new URLSearchParams({
+    response_type: "code",
+    client_id: params.clientId ?? CF_OAUTH_CLIENT_ID,
+    redirect_uri: params.redirectUri ?? CF_OAUTH_REDIRECT_URI,
+    scope: scopes.join(" "),
+    state: params.state,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  return `${CF_OAUTH_AUTH_URL}?${q.toString()}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+  token_type?: string;
+  error?: string;
+  error_description?: string;
+}
+
+async function postToken(params: URLSearchParams): Promise<CloudflareOAuthTokens> {
+  const res = await fetch(CF_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": getUserAgent(),
+    },
+    body: params.toString(),
+  });
+  let json: TokenResponse;
+  try {
+    json = (await res.json()) as TokenResponse;
+  } catch {
+    throw new CloudflareOAuthError(`Cloudflare token endpoint returned HTTP ${res.status} with a non-JSON body`);
+  }
+  if (!res.ok || json.error || !json.access_token) {
+    const code = json.error ?? `http_${res.status}`;
+    throw new CloudflareOAuthError(
+      `Cloudflare OAuth token request failed: ${code}${json.error_description ? ` — ${json.error_description}` : ""}`,
+      code,
+      json.error_description,
+    );
+  }
+  return {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token,
+    expiresAt: Date.now() + Math.max(60, json.expires_in ?? 3600) * 1000,
+    scopes: json.scope ? json.scope.split(" ").filter(Boolean) : [],
+  };
+}
+
+export async function exchangeCodeForTokens(args: {
+  code: string;
+  codeVerifier: string;
+  clientId?: string;
+  redirectUri?: string;
+}): Promise<CloudflareOAuthTokens> {
+  return postToken(
+    new URLSearchParams({
+      grant_type: "authorization_code",
+      code: args.code,
+      redirect_uri: args.redirectUri ?? CF_OAUTH_REDIRECT_URI,
+      client_id: args.clientId ?? CF_OAUTH_CLIENT_ID,
+      code_verifier: args.codeVerifier,
+    }),
+  );
+}
+
+export async function refreshCloudflareToken(
+  refreshToken: string,
+  clientId: string = CF_OAUTH_CLIENT_ID,
+): Promise<CloudflareOAuthTokens> {
+  const fresh = await postToken(
+    new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+    }),
+  );
+  // Cloudflare rotates refresh tokens; if the response omits one, keep the old.
+  return { ...fresh, refreshToken: fresh.refreshToken ?? refreshToken };
+}
+
+export async function revokeCloudflareToken(
+  refreshToken: string,
+  clientId: string = CF_OAUTH_CLIENT_ID,
+): Promise<void> {
+  try {
+    await fetch(CF_OAUTH_REVOKE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", "User-Agent": getUserAgent() },
+      body: new URLSearchParams({ token: refreshToken, client_id: clientId }).toString(),
+    });
+  } catch (e) {
+    logger.warn("cloudflare-oauth:revoke_failed", { error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
+/** True when the token is expired or within REFRESH_SKEW_MS of expiring. */
+export function tokenNeedsRefresh(expiresAt: number, now: number = Date.now(), skewMs: number = REFRESH_SKEW_MS): boolean {
+  return expiresAt - now <= skewMs;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cloudflare API helpers used right after login
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function listCloudflareAccounts(accessToken: string): Promise<CloudflareAccount[]> {
+  const res = await fetch("https://api.cloudflare.com/client/v4/accounts?per_page=50", {
+    headers: { Authorization: `Bearer ${accessToken}`, "User-Agent": getUserAgent() },
+  });
+  const json = (await res.json().catch(() => ({}))) as {
+    success?: boolean;
+    result?: Array<{ id: string; name: string }>;
+    errors?: Array<{ message?: string }>;
+  };
+  if (!res.ok || !json.success || !Array.isArray(json.result)) {
+    const msg = json.errors?.map((e) => e.message).filter(Boolean).join("; ") || `HTTP ${res.status}`;
+    throw new CloudflareOAuthError(`Couldn't list your Cloudflare accounts: ${msg}`);
+  }
+  return json.result.map((a) => ({ id: a.id, name: a.name }));
+}
+
+export async function whoAmI(accessToken: string): Promise<{ email?: string; id?: string } | null> {
+  try {
+    const res = await fetch("https://api.cloudflare.com/client/v4/user", {
+      headers: { Authorization: `Bearer ${accessToken}`, "User-Agent": getUserAgent() },
+    });
+    const json = (await res.json()) as { success?: boolean; result?: { email?: string; id?: string } };
+    return json.success && json.result ? json.result : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loopback callback server
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SUCCESS_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>kimiflare — signed in</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e6e6e6;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+.card{max-width:28rem;padding:2rem 2.5rem;border:1px solid #2a2f3a;border-radius:12px;background:#151922}h1{margin:0 0 .5rem;font-size:1.4rem;color:#f38020}p{margin:.25rem 0;color:#b9c0cc}</style></head>
+<body><div class="card"><h1>✓ Signed in to kimiflare</h1><p>You can close this tab and return to your terminal.</p></div></body></html>`;
+
+function errorHtml(msg: string): string {
+  const safe = msg.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" })[c] ?? c);
+  return `<!doctype html><html><head><meta charset="utf-8"><title>kimiflare — sign-in failed</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e6e6e6;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+.card{max-width:32rem;padding:2rem 2.5rem;border:1px solid #2a2f3a;border-radius:12px;background:#151922}h1{margin:0 0 .5rem;font-size:1.4rem;color:#ff6b6b}p{color:#b9c0cc}</style></head>
+<body><div class="card"><h1>Sign-in failed</h1><p>${safe}</p><p>Return to your terminal and try again.</p></div></body></html>`;
+}
+
+export interface LoginWithCloudflareOptions {
+  /** Called with the URL the user must open. The caller decides whether to auto-open a browser. */
+  onAuthUrl: (url: string) => void;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  clientId?: string;
+  scopes?: readonly string[];
+  /** Override the callback port (tests). */
+  port?: number;
+}
+
+/**
+ * Run the full interactive flow. Resolves with the tokens once the user has
+ * approved in the browser. Rejects on timeout, abort, or an OAuth error.
+ */
+export async function loginWithCloudflare(opts: LoginWithCloudflareOptions): Promise<CloudflareOAuthTokens> {
+  const clientId = opts.clientId ?? CF_OAUTH_CLIENT_ID;
+  if (!isCloudflareLoginConfigured(clientId)) {
+    throw new CloudflareOAuthError(
+      "Log in with Cloudflare isn't configured in this build (no OAuth client id). " +
+        "Set KIMIFLARE_CF_OAUTH_CLIENT_ID, or paste an API token instead — see docs/login-with-cloudflare.md.",
+      "not_configured",
+    );
+  }
+  const port = opts.port ?? CF_OAUTH_CALLBACK_PORT;
+  const redirectUri = `http://localhost:${port}${CF_OAUTH_CALLBACK_PATH}`;
+  const { verifier, challenge } = generatePkce();
+  const state = randomFromCharset(32);
+
+  return new Promise<CloudflareOAuthTokens>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onAbort);
+      server.close();
+      fn();
+    };
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+      if (url.pathname !== CF_OAUTH_CALLBACK_PATH) {
+        res.writeHead(404).end();
+        return;
+      }
+      const err = url.searchParams.get("error");
+      const code = url.searchParams.get("code");
+      const gotState = url.searchParams.get("state");
+      if (err) {
+        const desc = url.searchParams.get("error_description") ?? "";
+        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" }).end(errorHtml(`${err}${desc ? `: ${desc}` : ""}`));
+        finish(() => reject(new CloudflareOAuthError(`Cloudflare sign-in was not completed: ${err}${desc ? ` — ${desc}` : ""}`, err, desc)));
+        return;
+      }
+      if (!code || gotState !== state) {
+        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" }).end(errorHtml("Invalid callback (missing code or state mismatch)."));
+        finish(() => reject(new CloudflareOAuthError("OAuth callback was missing the code or had a mismatched state.", "invalid_callback")));
+        return;
+      }
+      // Exchange first, then answer the browser, so a failed exchange shows an error page.
+      exchangeCodeForTokens({ code, codeVerifier: verifier, clientId, redirectUri })
+        .then((tokens) => {
+          res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" }).end(SUCCESS_HTML);
+          finish(() => resolve(tokens));
+        })
+        .catch((e: unknown) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" }).end(errorHtml(msg));
+          finish(() => reject(e instanceof Error ? e : new CloudflareOAuthError(msg)));
+        });
+    });
+
+    const onAbort = () => finish(() => reject(new CloudflareOAuthError("Sign-in cancelled.", "aborted")));
+    const timer = setTimeout(
+      () => finish(() => reject(new CloudflareOAuthError("Timed out waiting for the browser sign-in. Please try again.", "timeout"))),
+      opts.timeoutMs ?? LOGIN_TIMEOUT_MS,
+    );
+    opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+    server.on("error", (e: NodeJS.ErrnoException) => {
+      const msg =
+        e.code === "EADDRINUSE"
+          ? `Port ${port} is already in use (another kimiflare or wrangler login in progress?). Close it and try again.`
+          : `Couldn't start the local sign-in callback server: ${e.message}`;
+      finish(() => reject(new CloudflareOAuthError(msg, e.code)));
+    });
+    server.listen(port, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo | null;
+      logger.debug("cloudflare-oauth:listening", { port: addr?.port });
+      opts.onAuthUrl(
+        buildAuthorizeUrl({ clientId, redirectUri, scopes: opts.scopes, state, codeChallenge: challenge }),
+      );
+    });
+  });
+}

--- a/src/cloud/cloudflare-session.test.ts
+++ b/src/cloud/cloudflare-session.test.ts
@@ -1,0 +1,129 @@
+/**
+ * "Log in with Cloudflare" sessions: loadConfig() surfaces the stored OAuth
+ * block, and refreshes a stale access token (persisting the rotated refresh
+ * token) so the rest of the app can keep treating cfg.apiToken as a plain
+ * bearer token.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, refreshCloudflareSession, patchPersistedConfig } from "../config.js";
+import { CF_OAUTH_TOKEN_URL } from "./cloudflare-oauth.js";
+
+const ENV = ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN", "CF_ACCOUNT_ID", "CF_API_TOKEN", "XDG_CONFIG_HOME", "KIMIFLARE_CLOUD"] as const;
+
+describe("Log in with Cloudflare session handling", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let tokenCalls = 0;
+  let dir = "";
+  const saved = new Map<string, string | undefined>();
+
+  before(async () => {
+    for (const k of ENV) { saved.set(k, process.env[k]); delete process.env[k]; }
+    dir = await mkdtemp(join(tmpdir(), "kimiflare-oauth-session-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    await mkdir(join(dir, "kimiflare"), { recursive: true });
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === CF_OAUTH_TOKEN_URL) {
+        tokenCalls++;
+        const body = new URLSearchParams(String(init?.body ?? ""));
+        assert.strictEqual(body.get("grant_type"), "refresh_token");
+        assert.strictEqual(body.get("refresh_token"), "cfort_old");
+        return new Response(
+          JSON.stringify({ access_token: "cfoat_fresh", refresh_token: "cfort_rotated", expires_in: 3600, scope: "aig.read ai.read" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return originalFetch(input, init);
+    };
+  });
+  after(async () => {
+    globalThis.fetch = originalFetch;
+    for (const k of ENV) { const v = saved.get(k); if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loadConfig passes cloudflareOAuth through and leaves a still-valid token alone", async () => {
+    tokenCalls = 0;
+    await writeFile(
+      join(dir, "kimiflare", "config.json"),
+      JSON.stringify({
+        accountId: "acct",
+        apiToken: "cfoat_valid",
+        model: "@cf/moonshotai/kimi-k2.6",
+        cloudflareOAuth: { refreshToken: "cfort_old", expiresAt: Date.now() + 60 * 60_000, scopes: ["aig.read"], clientId: "cid", email: "me@example.com" },
+      }),
+    );
+    const cfg = await loadConfig();
+    assert.ok(cfg);
+    assert.strictEqual(cfg.apiToken, "cfoat_valid");
+    assert.strictEqual(cfg.cloudflareOAuth?.email, "me@example.com");
+    assert.strictEqual(tokenCalls, 0);
+  });
+
+  it("loadConfig refreshes an expiring token and persists the rotated refresh token", async () => {
+    tokenCalls = 0;
+    await writeFile(
+      join(dir, "kimiflare", "config.json"),
+      JSON.stringify({
+        accountId: "acct",
+        apiToken: "cfoat_stale",
+        model: "@cf/moonshotai/kimi-k2.6",
+        theme: "everforest-light",
+        cloudflareOAuth: { refreshToken: "cfort_old", expiresAt: Date.now() + 60_000, scopes: ["aig.read"], clientId: "cid" },
+      }),
+    );
+    const cfg = await loadConfig();
+    assert.ok(cfg);
+    assert.strictEqual(tokenCalls, 1);
+    assert.strictEqual(cfg.apiToken, "cfoat_fresh");
+    assert.strictEqual(cfg.cloudflareOAuth?.refreshToken, "cfort_rotated");
+    assert.ok(cfg.cloudflareOAuth!.expiresAt > Date.now() + 50 * 60_000);
+    // Persisted with unrelated fields intact.
+    const onDisk = JSON.parse(await readFile(join(dir, "kimiflare", "config.json"), "utf8"));
+    assert.strictEqual(onDisk.apiToken, "cfoat_fresh");
+    assert.strictEqual(onDisk.cloudflareOAuth.refreshToken, "cfort_rotated");
+    assert.strictEqual(onDisk.theme, "everforest-light");
+    assert.strictEqual(onDisk.accountId, "acct");
+  });
+
+  it("an env CLOUDFLARE_API_TOKEN overrides the OAuth session entirely", async () => {
+    tokenCalls = 0;
+    process.env.CLOUDFLARE_ACCOUNT_ID = "envacct";
+    process.env.CLOUDFLARE_API_TOKEN = "envtoken";
+    try {
+      const cfg = await loadConfig();
+      assert.ok(cfg);
+      assert.strictEqual(cfg.apiToken, "envtoken");
+      assert.strictEqual(cfg.cloudflareOAuth, undefined);
+      assert.strictEqual(tokenCalls, 0);
+    } finally {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      delete process.env.CLOUDFLARE_API_TOKEN;
+    }
+  });
+
+  it("refreshCloudflareSession is a no-op for manual API tokens and for fresh tokens", async () => {
+    assert.strictEqual(await refreshCloudflareSession({ accountId: "a", apiToken: "manual", model: "m" }), null);
+    assert.strictEqual(
+      await refreshCloudflareSession({
+        accountId: "a",
+        apiToken: "cfoat",
+        model: "m",
+        cloudflareOAuth: { refreshToken: "cfort_old", expiresAt: Date.now() + 3_600_000, scopes: [], clientId: "cid" },
+      }),
+      null,
+    );
+  });
+
+  it("patchPersistedConfig merges into the file without clobbering other keys", async () => {
+    await writeFile(join(dir, "kimiflare", "config.json"), JSON.stringify({ accountId: "a", apiToken: "t", model: "m", theme: "x" }));
+    await patchPersistedConfig({ apiToken: "t2", cloudMode: undefined });
+    const onDisk = JSON.parse(await readFile(join(dir, "kimiflare", "config.json"), "utf8"));
+    assert.deepStrictEqual(onDisk, { accountId: "a", apiToken: "t2", model: "m", theme: "x" });
+  });
+});

--- a/src/cloud/cloudflare-session.test.ts
+++ b/src/cloud/cloudflare-session.test.ts
@@ -127,3 +127,29 @@ describe("Log in with Cloudflare session handling", () => {
     assert.deepStrictEqual(onDisk, { accountId: "a", apiToken: "t2", model: "m", theme: "x" });
   });
 });
+
+describe("loadConfig honours the persisted model", () => {
+  it("keeps the model saved via /model instead of resetting to DEFAULT_MODEL", async () => {
+    const saved = { xdg: process.env.XDG_CONFIG_HOME, model: process.env.KIMI_MODEL, acct: process.env.CLOUDFLARE_ACCOUNT_ID, tok: process.env.CLOUDFLARE_API_TOKEN };
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-model-persist-"));
+    try {
+      process.env.XDG_CONFIG_HOME = dir;
+      delete process.env.KIMI_MODEL;
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      delete process.env.CLOUDFLARE_API_TOKEN;
+      await mkdir(join(dir, "kimiflare"), { recursive: true });
+      await writeFile(join(dir, "kimiflare", "config.json"), JSON.stringify({ accountId: "a", apiToken: "t", model: "moonshotai/kimi-k3" }));
+      const cfg = await loadConfig();
+      assert.strictEqual(cfg?.model, "moonshotai/kimi-k3");
+      // KIMI_MODEL still overrides.
+      process.env.KIMI_MODEL = "@cf/zai-org/glm-5.2";
+      assert.strictEqual((await loadConfig())?.model, "@cf/zai-org/glm-5.2");
+    } finally {
+      if (saved.xdg === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = saved.xdg;
+      if (saved.model === undefined) delete process.env.KIMI_MODEL; else process.env.KIMI_MODEL = saved.model;
+      if (saved.acct !== undefined) process.env.CLOUDFLARE_ACCOUNT_ID = saved.acct;
+      if (saved.tok !== undefined) process.env.CLOUDFLARE_API_TOKEN = saved.tok;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -340,7 +340,9 @@ export async function loadConfig(): Promise<KimiConfig | null> {
 
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
-  const envModel = process.env.KIMI_MODEL ?? DEFAULT_MODEL;
+  // KIMI_MODEL is an override, not a default: leave it undefined when unset so
+  // the persisted `model` (set via /model) is honoured on the next launch.
+  const envModel = process.env.KIMI_MODEL || undefined;
   const envEffort = readReasoningEffortEnv();
   const envCoauthor = readCoauthorEnv();
   const envAiGatewayId = process.env.KIMIFLARE_AI_GATEWAY_ID;
@@ -391,7 +393,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     return {
       accountId: "",
       apiToken: "",
-      model: envModel,
+      model: envModel ?? DEFAULT_MODEL,
       cloudMode: true,
       reasoningEffort: envEffort,
       coauthor: envCoauthor?.enabled ?? true,
@@ -436,7 +438,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     return {
       accountId: envAccount,
       apiToken: envToken,
-      model: envModel,
+      model: envModel ?? DEFAULT_MODEL,
       aiGatewayId: envAiGatewayId,
       aiGatewayCacheTtl: envAiGatewayCacheTtl,
       aiGatewaySkipCache: envAiGatewaySkipCache,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,12 @@
 import { readFile, mkdir, writeFile, chmod } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isCloudModeAvailable } from "./cloud/availability.js";
+import {
+  refreshCloudflareToken,
+  tokenNeedsRefresh,
+  CF_OAUTH_CLIENT_ID,
+} from "./cloud/cloudflare-oauth.js";
 
 export type ReasoningEffort = "low" | "medium" | "high";
 export const EFFORTS: readonly ReasoningEffort[] = ["low", "medium", "high"];
@@ -33,10 +39,33 @@ export type PermissionRule = "allow" | "deny" | "ask";
 /** Per-tool permission rules keyed by glob pattern. */
 export type PermissionRules = Record<string, PermissionRule>;
 
+/**
+ * Present when the Cloudflare credentials came from "Log in with Cloudflare"
+ * (OAuth 2.0 + PKCE, see src/cloud/cloudflare-oauth.ts). `apiToken` holds the
+ * current short-lived access token; this block holds what we need to rotate
+ * it silently in the background.
+ */
+export interface CloudflareOAuthConfig {
+  /** Refresh token (rotates on every refresh). Absent if offline_access was not granted. */
+  refreshToken?: string;
+  /** Access-token expiry, epoch milliseconds. */
+  expiresAt: number;
+  /** Scopes granted on the consent screen. */
+  scopes: string[];
+  /** OAuth client id the tokens were issued to. */
+  clientId: string;
+  /** Email of the signed-in Cloudflare user (display only). */
+  email?: string;
+  /** Display name of the selected account (display only). */
+  accountName?: string;
+}
+
 export interface KimiConfig {
   accountId: string;
   apiToken: string;
   model: string;
+  /** Set when apiToken is an OAuth access token from "Log in with Cloudflare". */
+  cloudflareOAuth?: CloudflareOAuthConfig;
   aiGatewayId?: string;
   aiGatewayCacheTtl?: number;
   aiGatewaySkipCache?: boolean;
@@ -94,7 +123,13 @@ export interface KimiConfig {
   githubTokenExpiry?: number;
   /** Default GitHub repo for remote sessions (owner/repo). */
   githubRepo?: string;
-  /** Enable cloud mode: use api.kimiflare.com instead of direct Workers AI. */
+  /**
+   * Enable cloud mode: use api.kimiflare.com instead of direct Workers AI.
+   * NOTE: KimiFlare Cloud is temporarily hidden (see src/cloud/availability.ts).
+   * While it is hidden, loadConfig() never returns cloudMode=true — a persisted
+   * `cloudMode: true` or `KIMIFLARE_CLOUD=1` is ignored and the user is routed
+   * to BYOK onboarding instead. The field is kept so existing configs still parse.
+   */
   cloudMode?: boolean;
   /** Shell override for the bash tool. "auto" (default) detects the platform, or specify "bash", "cmd", "powershell", or an absolute path. */
   shell?: string;
@@ -336,7 +371,11 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envCodeMode = readBooleanEnv("KIMIFLARE_CODE_MODE");
   const envCostAttribution = readBooleanEnv("KIMI_COST_ATTRIBUTION");
   const envFilePicker = readBooleanEnv("KIMIFLARE_FILE_PICKER");
-  const envCloudMode = readBooleanEnv("KIMIFLARE_CLOUD");
+  // KimiFlare Cloud is temporarily hidden: while isCloudModeAvailable() is
+  // false, neither KIMIFLARE_CLOUD=1 nor a persisted cloudMode:true can put the
+  // user on the managed service. See src/cloud/availability.ts.
+  const cloudAllowed = isCloudModeAvailable();
+  const envCloudMode = cloudAllowed ? readBooleanEnv("KIMIFLARE_CLOUD") : undefined;
   const envShell = process.env.KIMIFLARE_SHELL;
   const envProviderKeys = readProviderKeysEnv();
   const envUnifiedBilling = readBooleanEnv("KIMIFLARE_UNIFIED_BILLING");
@@ -420,7 +459,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       codeMode: envCodeMode ?? true,
       costAttribution: envCostAttribution ?? true,
       filePicker: envFilePicker ?? true,
-      cloudMode: envCloudMode ?? persisted?.cloudMode,
+      cloudMode: cloudAllowed ? (envCloudMode ?? persisted?.cloudMode) : undefined,
       shell: envShell,
       // Settings-only fields: env vars don't carry these, so we read
       // them from the persisted file (when present) so the user's TUI
@@ -450,7 +489,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
 
   if (persisted) {
     const parsed = persisted;
-    if (parsed.cloudMode) {
+    if (parsed.cloudMode && cloudAllowed) {
       return {
         accountId: envAccount ?? parsed.accountId ?? "",
         apiToken: envToken ?? parsed.apiToken ?? "",
@@ -497,9 +536,11 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     }
     if (parsed.accountId && parsed.apiToken) {
       warnIfBlankGatewayId(parsed.aiGatewayId, "config");
-      return {
+      return withFreshCloudflareToken({
         accountId: envAccount ?? parsed.accountId,
         apiToken: envToken ?? parsed.apiToken,
+        // An env token overrides the stored OAuth session entirely.
+        cloudflareOAuth: envToken ? undefined : parsed.cloudflareOAuth,
         model: envModel ?? parsed.model ?? DEFAULT_MODEL,
         aiGatewayId: envAiGatewayId ?? parsed.aiGatewayId,
         aiGatewayCacheTtl: envAiGatewayCacheTtl ?? parsed.aiGatewayCacheTtl,
@@ -525,7 +566,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         codeMode: envCodeMode ?? parsed.codeMode ?? true,
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? true,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
-        cloudMode: envCloudMode ?? parsed.cloudMode,
+        cloudMode: cloudAllowed ? (envCloudMode ?? parsed.cloudMode) : undefined,
         theme: parsed.theme,
         shell: envShell ?? parsed.shell,
         uiEngine: parsed.uiEngine,
@@ -547,10 +588,93 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         workerPreReadMaxChars: envWorkerPreReadMaxChars ?? parsed.workerPreReadMaxChars,
         preferPullRequests: envPreferPullRequests ?? parsed.preferPullRequests ?? true,
         allowDirectPush: envAllowDirectPush ?? parsed.allowDirectPush ?? false,
-      };
+      });
     }
   }
   return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Log in with Cloudflare — background token refresh
+// ─────────────────────────────────────────────────────────────────────────────
+
+let refreshInFlight: Promise<KimiConfig | null> | null = null;
+
+/**
+ * If `cfg` carries an OAuth session whose access token is expired or about
+ * to expire, refresh it, persist the rotated tokens, and return the updated
+ * config. Returns `null` when nothing needed to change. Never throws — on
+ * failure the caller keeps the current token and the next 401 tells the
+ * user to run `kimiflare auth cloudflare` again.
+ */
+export async function refreshCloudflareSession(cfg: KimiConfig): Promise<KimiConfig | null> {
+  const oauth = cfg.cloudflareOAuth;
+  if (!oauth?.refreshToken) return null;
+  if (!tokenNeedsRefresh(oauth.expiresAt)) return null;
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
+    try {
+      const fresh = await refreshCloudflareToken(oauth.refreshToken!, oauth.clientId || CF_OAUTH_CLIENT_ID);
+      const nextOAuth: CloudflareOAuthConfig = {
+        ...oauth,
+        refreshToken: fresh.refreshToken ?? oauth.refreshToken,
+        expiresAt: fresh.expiresAt,
+        scopes: fresh.scopes.length > 0 ? fresh.scopes : oauth.scopes,
+      };
+      await patchPersistedConfig({ apiToken: fresh.accessToken, cloudflareOAuth: nextOAuth });
+      return { ...cfg, apiToken: fresh.accessToken, cloudflareOAuth: nextOAuth };
+    } catch (e) {
+      // Another kimiflare process may have rotated the refresh token first —
+      // re-read the file and adopt its session if it is newer than ours.
+      try {
+        const raw = await readFile(configPath(), "utf8");
+        const onDisk = JSON.parse(raw) as Partial<KimiConfig>;
+        if (
+          onDisk.cloudflareOAuth &&
+          onDisk.apiToken &&
+          onDisk.cloudflareOAuth.expiresAt > oauth.expiresAt
+        ) {
+          return { ...cfg, apiToken: onDisk.apiToken, cloudflareOAuth: onDisk.cloudflareOAuth };
+        }
+      } catch {
+        /* ignore */
+      }
+      // eslint-disable-next-line no-console
+      console.warn(
+        `kimiflare: couldn't refresh your Cloudflare login (${e instanceof Error ? e.message : String(e)}). ` +
+          "If requests start failing with 401, run `kimiflare auth cloudflare` to sign in again.",
+      );
+      return null;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
+async function withFreshCloudflareToken(cfg: KimiConfig): Promise<KimiConfig> {
+  if (!cfg.cloudflareOAuth?.refreshToken) return cfg;
+  return (await refreshCloudflareSession(cfg)) ?? cfg;
+}
+
+/**
+ * Merge `patch` into the on-disk config without disturbing unrelated fields
+ * (unlike saveConfig(), which rewrites the whole file from an in-memory cfg
+ * that may carry env-derived defaults).
+ */
+export async function patchPersistedConfig(patch: Partial<KimiConfig>): Promise<string> {
+  const p = configPath();
+  let existing: Partial<KimiConfig> = {};
+  try {
+    existing = JSON.parse(await readFile(p, "utf8")) as Partial<KimiConfig>;
+  } catch {
+    /* no file yet */
+  }
+  const merged = { ...existing, ...patch };
+  await mkdir(join(p, ".."), { recursive: true });
+  await writeFile(p, JSON.stringify(merged, null, 2), "utf8");
+  await chmod(p, 0o600);
+  return p;
 }
 
 /** Resolve and validate a worker budget, applying the hard ceiling.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { loadConfig, saveConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL, configPath } from "./config.js";
+import { isCloudModeAvailable, CLOUD_UNAVAILABLE_NOTICE } from "./cloud/availability.js";
 import { isKillSwitchError } from "./util/errors.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
 import { checkForUpdate } from "./util/update-check.js";
@@ -14,6 +15,7 @@ import type { PrintFormat } from "./print-mode.js";
 /** Best-effort synchronous check for whether cloud mode is the default.
  *  Used only for static --help copy; runtime resolution uses loadConfig(). */
 function isCloudModeConfigured(): boolean {
+  if (!isCloudModeAvailable()) return false;
   if (process.env.KIMIFLARE_CLOUD === "1" || process.env.KIMIFLARE_CLOUD === "true") return true;
   try {
     const raw = readFileSync(configPath(), "utf8");
@@ -34,7 +36,14 @@ program
   .version(getAppVersion())
   .option("-p, --print <prompt>", "one-shot mode: send prompt, stream reply to stdout, exit")
   .option("-m, --model <id>", `model id (defaults to ${helpDefaultModel})`)
-  .option("--cloud", "use Kimiflare Cloud (api.kimiflare.com) instead of direct Workers AI")
+  // KimiFlare Cloud is temporarily hidden (src/cloud/availability.ts): keep the
+  // flag parseable so old scripts don't break, but hide it from --help and
+  // ignore it at runtime while the managed service is switched off.
+  .addOption(
+    isCloudModeAvailable()
+      ? new Option("--cloud", "use Kimiflare Cloud (api.kimiflare.com) instead of direct Workers AI")
+      : new Option("--cloud", "(temporarily unavailable) use Kimiflare Cloud").hideHelp(),
+  )
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
   .option("--reasoning", "include reasoning in stdout (print mode only)")
   .option("--thinking", "alias for --reasoning")
@@ -80,9 +89,13 @@ program
   });
 
 program
-  .command("usage")
+  .command("usage", { hidden: !isCloudModeAvailable() })
   .description("Show Kimiflare Cloud token usage (requires cloud authentication)")
   .action(async () => {
+    if (!isCloudModeAvailable()) {
+      console.error(CLOUD_UNAVAILABLE_NOTICE);
+      process.exit(1);
+    }
     const { loadCloudCredentials } = await import("./cloud/auth.js");
     const creds = await loadCloudCredentials();
     if (!creds) {
@@ -144,6 +157,79 @@ program
   .command("auth")
   .description("Authenticate with external services")
   .addCommand(
+    new Command("cloudflare")
+      .description("Log in with Cloudflare (browser OAuth) — no API token or Account ID to copy")
+      .option("--account <id>", "Cloudflare account id to use (skips the picker for multi-account users)")
+      .option("--no-browser", "print the sign-in URL instead of opening a browser")
+      .action(async (cmdOpts: { account?: string; browser?: boolean }) => {
+        const { loginWithCloudflare, listCloudflareAccounts, whoAmI, CF_OAUTH_CLIENT_ID } = await import(
+          "./cloud/cloudflare-oauth.js"
+        );
+        const { patchPersistedConfig } = await import("./config.js");
+        try {
+          const tokens = await loginWithCloudflare({
+            onAuthUrl: (url) => {
+              console.log("\nLog in with Cloudflare");
+              if (cmdOpts.browser !== false) {
+                console.log("Opening your browser… approve kimiflare there, then come back here.");
+                void import("./ui/app-helpers.js").then(({ openBrowser }) => openBrowser(url));
+              }
+              console.log(`If the browser didn't open, visit:\n  ${url}\n`);
+            },
+          });
+          const [me, accounts] = await Promise.all([whoAmI(tokens.accessToken), listCloudflareAccounts(tokens.accessToken)]);
+          if (accounts.length === 0) {
+            console.error("Signed in, but this Cloudflare user has no accounts kimiflare can use.");
+            process.exit(1);
+          }
+          let picked = accounts.length === 1 ? accounts[0]! : undefined;
+          if (cmdOpts.account) {
+            picked = accounts.find((a) => a.id === cmdOpts.account);
+            if (!picked) {
+              console.error(`Account ${cmdOpts.account} is not one of your accounts:`);
+              for (const a of accounts) console.error(`  ${a.id}  ${a.name}`);
+              process.exit(1);
+            }
+          }
+          if (!picked) {
+            console.log("Which Cloudflare account should kimiflare use?");
+            accounts.forEach((a, i) => console.log(`  [${i + 1}] ${a.name}  (${a.id})`));
+            const { createInterface } = await import("node:readline/promises");
+            const rl = createInterface({ input: process.stdin, output: process.stdout });
+            const answer = (await rl.question(`Select 1-${accounts.length} [1]: `)).trim();
+            rl.close();
+            const idx = answer ? parseInt(answer, 10) - 1 : 0;
+            picked = accounts[idx];
+            if (!picked) {
+              console.error("Invalid selection.");
+              process.exit(1);
+            }
+          }
+          const existing = await loadConfig().catch(() => null);
+          const savedTo = await patchPersistedConfig({
+            accountId: picked.id,
+            apiToken: tokens.accessToken,
+            model: existing?.model ?? DEFAULT_MODEL,
+            cloudflareOAuth: {
+              refreshToken: tokens.refreshToken,
+              expiresAt: tokens.expiresAt,
+              scopes: tokens.scopes,
+              clientId: CF_OAUTH_CLIENT_ID,
+              email: me?.email,
+              accountName: picked.name,
+            },
+            // A fresh Cloudflare login supersedes any managed-cloud mode.
+            cloudMode: undefined,
+          });
+          console.log(`\n✓ Signed in${me?.email ? ` as ${me.email}` : ""} · account "${picked.name}" (${picked.id})`);
+          console.log(`Saved to ${savedTo}. Run \`kimiflare\` to start.`);
+        } catch (err) {
+          console.error("Log in with Cloudflare failed:", err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+      }),
+  )
+  .addCommand(
     new Command("github")
       .description("Authenticate with GitHub via OAuth device flow")
       .action(async () => {
@@ -163,6 +249,10 @@ program
     new Command("cloud")
       .description("Authenticate with Kimiflare Cloud")
       .action(async () => {
+        if (!isCloudModeAvailable()) {
+          console.error(CLOUD_UNAVAILABLE_NOTICE);
+          process.exit(1);
+        }
         const { authenticateDevice } = await import("./cloud/auth.js");
         try {
           const creds = await authenticateDevice(({ url, userCode, polling }) => {
@@ -209,8 +299,8 @@ program
           process.exit(1);
         }
       }),
-  )
-  ;
+    { hidden: !isCloudModeAvailable() },
+  );
 
 program
   .command("serve")
@@ -224,6 +314,21 @@ program
       process.exit(2);
     }
     const { startServer } = await import("./server/index.js");
+    // Long-running: rotate a "Log in with Cloudflare" access token in place
+    // (routes read config.apiToken on every request, so mutating the shared
+    // object is enough).
+    if (cfg.cloudflareOAuth?.refreshToken) {
+      const { refreshCloudflareSession } = await import("./config.js");
+      const timer = setInterval(() => {
+        void refreshCloudflareSession(cfg).then((next) => {
+          if (next) {
+            cfg.apiToken = next.apiToken;
+            cfg.cloudflareOAuth = next.cloudflareOAuth;
+          }
+        });
+      }, 60_000);
+      timer.unref();
+    }
     await startServer({
       port: cmdOpts.port,
       hostname: cmdOpts.hostname,
@@ -286,8 +391,12 @@ async function main() {
     lspProjectPath = resolved.projectPath;
   }
 
-  // Handle cloud mode
-  const cloudMode = opts.cloud ?? cfg?.cloudMode ?? false;
+  // Handle cloud mode. While KimiFlare Cloud is hidden (src/cloud/availability.ts)
+  // `--cloud` is a no-op: we tell the user once and continue with BYOK.
+  if (opts.cloud && !isCloudModeAvailable()) {
+    console.error(`kimiflare: --cloud ignored — ${CLOUD_UNAVAILABLE_NOTICE}`);
+  }
+  const cloudMode = isCloudModeAvailable() && (opts.cloud ?? cfg?.cloudMode ?? false);
   let cloudToken: string | undefined;
   let cloudDeviceId: string | undefined;
   if (cloudMode) {

--- a/src/models/next-step.ts
+++ b/src/models/next-step.ts
@@ -1,5 +1,5 @@
 import type { KimiConfig } from "../config.js";
-import { isUnifiedEligible, type ModelEntry } from "./registry.js";
+import { isUnifiedEligible, routeFor, type ModelEntry } from "./registry.js";
 
 export type NextStep =
   | { kind: "ready" }
@@ -18,6 +18,11 @@ export type NextStep =
  */
 export function decideNextStep(cfg: KimiConfig | null, model: ModelEntry): NextStep {
   if (model.provider === "workers-ai") return { kind: "ready" };
+  // Cloudflare-catalog models (e.g. moonshotai/kimi-k3) are paid from the
+  // account's AI Gateway credits via Cloudflare's unified REST API: no
+  // provider key, and a gateway is optional (Cloudflare uses/creates
+  // "default" when none is set).
+  if (routeFor(model) === "cf-catalog") return { kind: "ready" };
   if (!cfg) return { kind: "ready" };
   if (!cfg.aiGatewayId) return { kind: "needs-gateway" };
 

--- a/src/models/registry.test.ts
+++ b/src/models/registry.test.ts
@@ -1,18 +1,40 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { getModel, inferProvider, isUnifiedEligible } from "./registry.js";
+import { getModel, getModelOrInfer, inferProvider, isUnifiedEligible, routeFor } from "./registry.js";
+import { decideNextStep } from "./next-step.js";
 
 describe("registry: Moonshot K3", () => {
   it("infers moonshotai provider from moonshotai/kimi-k3", () => {
     assert.strictEqual(inferProvider("moonshotai/kimi-k3"), "moonshotai");
   });
 
-  it("seeds moonshotai/kimi-k3 as BYOK-only (Unified Billing not available)", () => {
+  it("seeds moonshotai/kimi-k3 as a Cloudflare-catalog model paid via Unified Billing", () => {
     const model = getModel("moonshotai/kimi-k3");
     assert.ok(model, "expected moonshotai/kimi-k3 to be seeded");
     assert.strictEqual(model!.provider, "moonshotai");
-    assert.strictEqual(model!.billingMode, "byok");
-    assert.strictEqual(isUnifiedEligible(model!), false);
+    assert.strictEqual(model!.billingMode, "unified");
+    assert.strictEqual(routeFor(model!), "cf-catalog");
+    assert.strictEqual(isUnifiedEligible(model!), true);
+    // K3 rejects any temperature other than 1.0 — the client must omit it.
+    assert.strictEqual(model!.supports.temperature, false);
+    assert.strictEqual(model!.contextWindow, 1_048_576);
+    assert.deepStrictEqual(model!.pricing, { inputPerMtok: 3.0, cachedInputPerMtok: 0.3, outputPerMtok: 15.0 });
+  });
+
+  it("K3 needs no provider key and no gateway: next step is ready", () => {
+    const model = getModel("moonshotai/kimi-k3")!;
+    assert.deepStrictEqual(decideNextStep(null, model), { kind: "ready" });
+    assert.deepStrictEqual(
+      decideNextStep({ accountId: "a", apiToken: "t", model: model.id }, model),
+      { kind: "ready" },
+    );
+  });
+
+  it("unknown moonshotai/* ids infer the cf-catalog route with unified billing", () => {
+    const inferred = getModelOrInfer("moonshotai/kimi-k3-future");
+    assert.strictEqual(inferred.provider, "moonshotai");
+    assert.strictEqual(inferred.billingMode, "unified");
+    assert.strictEqual(routeFor(inferred), "cf-catalog");
   });
 
   it("keeps Workers AI Kimi models on the workers-ai provider", () => {

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -2,22 +2,32 @@
  * Model registry: single source of truth for per-model capabilities, pricing,
  * and routing decisions.
  *
- * KimiFlare is built around Kimi models served through Cloudflare Workers AI.
- * Most seeded models are Workers AI models. AI Gateway is optional for those —
- * they also work via the direct api.cloudflare.com path. Provider-native models
- * (e.g. moonshotai/kimi-k3) require AI Gateway and are included so they work out
- * of the box once a gateway is configured.
+ * KimiFlare is built around Kimi models served through Cloudflare. Most seeded
+ * models are Workers AI models; AI Gateway is optional for those — they also
+ * work via the direct api.cloudflare.com path. Kimi K3 (moonshotai/kimi-k3) is
+ * a third-party model in Cloudflare's model catalog, paid from the account's
+ * AI Gateway credits, and works out of the box with just a Cloudflare token.
  *
- * Routing taxonomy:
- *   - Workers AI chat models go through EITHER:
+ * Routing taxonomy (see `routeFor()`):
+ *   - "workers-ai": Workers AI chat models go through EITHER:
  *     a) Direct path:  api.cloudflare.com/client/v4/accounts/{acct}/ai/run/{model}
  *     b) Gateway path: gateway.ai.cloudflare.com/v1/{acct}/{gw}/compat/chat/completions
  *     The choice is made at runtime based on whether aiGatewayId is configured.
- *   - Embeddings use the same dual-path logic:
+ *   - "cf-catalog": third-party models in Cloudflare's model catalog (e.g.
+ *     moonshotai/kimi-k3) go through Cloudflare's unified REST API
+ *     api.cloudflare.com/client/v4/accounts/{acct}/ai/v1/chat/completions with an
+ *     optional `cf-aig-gateway-id` header. Cloudflare pays the provider from the
+ *     account's AI Gateway credits (Unified Billing) — no provider key, and BYOK
+ *     is not supported on this path.
+ *   - "gateway": everything else (Anthropic, OpenAI, Google, OpenAI-compatible)
+ *     goes through the AI Gateway Universal Endpoint with provider auth
+ *     (Unified Billing where supported, else BYOK).
+ *   - Embeddings use the Workers AI dual-path logic:
  *     a) Direct:  api.cloudflare.com/client/v4/accounts/{acct}/ai/run/{model}
  *     b) Gateway: gateway.ai.cloudflare.com/v1/{acct}/{gw}/workers-ai/{model}
  *   - User-registered models (via ~/.kimiflare/models.json) can be any provider,
- *     but they require AI Gateway since only Workers AI has a direct path.
+ *     but "gateway"-routed ones require AI Gateway since only Workers AI has a
+ *     direct path.
  */
 
 export type ModelProvider =
@@ -83,9 +93,23 @@ const UNIFIED_BILLING_PROVIDERS: ReadonlySet<string> = new Set([
   "xai",
 ]);
 
+export type ModelRoute = "workers-ai" | "cf-catalog" | "gateway";
+
+/**
+ * Which transport a model uses. Moonshot models are only reachable through
+ * Cloudflare's model catalog (unified REST API + Unified Billing) — there is
+ * no provider-native Moonshot slug on AI Gateway.
+ */
+export function routeFor(entry: ModelEntry): ModelRoute {
+  if (entry.provider === "workers-ai") return "workers-ai";
+  if (entry.provider === "moonshotai") return "cf-catalog";
+  return "gateway";
+}
+
 /** True when the user can pay for this model through Cloudflare credits rather than BYOK. */
 export function isUnifiedEligible(entry: ModelEntry): boolean {
   if (entry.provider === "workers-ai") return false; // own billing track
+  if (routeFor(entry) === "cf-catalog") return true; // credits are the only option
   // For openai-compatible upstreams we key off the model-id prefix
   // (e.g. "groq/llama-3.3-70b-versatile" → "groq").
   const slashIdx = entry.id.indexOf("/");
@@ -105,18 +129,24 @@ const SEED: ModelEntry[] = [
     supports: { tools: true, reasoning: true, streaming: true, vision: true },
     billingMode: "unified",
   },
-  // ── Kimi K3 (AI Gateway / Moonshot AI, provider-native routing) ──────────
+  // ── Kimi K3 (Cloudflare model catalog, third-party, Unified Billing) ─────
+  // Verified live 2026-08-19 against
+  //   POST api.cloudflare.com/client/v4/accounts/{acct}/ai/v1/chat/completions
+  // with `cf-aig-gateway-id`: streaming, reasoning_content deltas, tool calls
+  // and usage all parse; Cloudflare pays Moonshot from AI Gateway credits.
+  // Pricing per Moonshot (platform.kimi.ai/docs/pricing/chat-k3): $3.00 in,
+  // $0.30 cached in, $15.00 out per 1M tokens; Cloudflare passes it through.
   {
     id: "moonshotai/kimi-k3",
     provider: "moonshotai",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 32_768,
-    // Placeholder pricing — verify against Cloudflare AI Gateway docs once rendered.
-    pricing: { inputPerMtok: 3.0, outputPerMtok: 15.0 },
-    supports: { tools: true, reasoning: true, streaming: true, vision: true },
-    // Cloudflare Unified Billing does not currently cover Moonshot AI.
-    // Use a Moonshot API key (BYOK) via cf-aig-authorization.
-    billingMode: "byok",
+    contextWindow: 1_048_576,
+    maxOutputTokens: 131_072,
+    pricing: { inputPerMtok: 3.0, cachedInputPerMtok: 0.3, outputPerMtok: 15.0 },
+    // K3 fixes temperature=1.0 — sending any other value is a 400
+    // ("invalid temperature: only 1 is allowed for this model"), so we omit it.
+    // Reasoning is always on; `reasoning_effort` low/medium/high are accepted.
+    supports: { tools: true, reasoning: true, streaming: true, vision: true, temperature: false },
+    billingMode: "unified",
   },
   {
     id: "@cf/moonshotai/kimi-k2.6",
@@ -175,7 +205,7 @@ export function getModelOrInfer(id: string): ModelEntry {
     maxOutputTokens: 4_096,
     pricing: { inputPerMtok: 0, outputPerMtok: 0 },
     supports: { tools: true, reasoning: false, streaming: true },
-    billingMode: provider === "workers-ai" ? "unified" : "byok",
+    billingMode: provider === "workers-ai" || provider === "moonshotai" ? "unified" : "byok",
   };
 }
 

--- a/src/ui/billing-chooser.tsx
+++ b/src/ui/billing-chooser.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 import type { ModelEntry, ModelProvider } from "../models/registry.js";
+import { isCloudModeAvailable } from "../cloud/availability.js";
 
 export type BillingChoice = "cloud" | "unified" | "byok";
 
@@ -28,7 +29,8 @@ export function BillingChooser({ model, onPick }: Props) {
   });
 
   const items: { label: string; value: BillingChoice }[] = [
-    ...(model.provider === "workers-ai"
+    // KimiFlare Cloud is temporarily hidden (src/cloud/availability.ts).
+    ...(model.provider === "workers-ai" && isCloudModeAvailable()
       ? [{ label: `Start free with Kimiflare Cloud  ·  5M tokens`, value: "cloud" as const }]
       : []),
     { label: `Use Cloudflare credits  ·  no extra key`, value: "unified" as const },

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -5,8 +5,14 @@ import { ModelPicker } from "./model-picker.js";
 import { BillingChooser, type BillingChoice } from "./billing-chooser.js";
 import { UnifiedBillingStatus } from "./unified-billing-status.js";
 import { KeyEntryModal, type KeyResult } from "./key-entry-modal.js";
-import { isUnifiedEligible, getModel, type ModelEntry } from "../models/registry.js";
-import { saveConfig, DEFAULT_MODEL, DEFAULT_CLOUD_MODEL, type KimiConfig } from "../config.js";
+import { isUnifiedEligible, getModel, routeFor, type ModelEntry } from "../models/registry.js";
+import {
+  saveConfig,
+  DEFAULT_MODEL,
+  DEFAULT_CLOUD_MODEL,
+  type KimiConfig,
+  type CloudflareOAuthConfig,
+} from "../config.js";
 import { openBrowser } from "./app-helpers.js";
 import { useTheme } from "./theme-context.js";
 import {
@@ -16,14 +22,26 @@ import {
   AiGatewayError,
   type Gateway,
 } from "../cloud/ai-gateway-api.js";
+import { isCloudModeAvailable } from "../cloud/availability.js";
+import {
+  loginWithCloudflare,
+  listCloudflareAccounts,
+  whoAmI,
+  isCloudflareLoginConfigured,
+  CF_OAUTH_CLIENT_ID,
+  type CloudflareAccount,
+} from "../cloud/cloudflare-oauth.js";
 
 interface Props {
-  onDone: (cfg: { accountId: string; apiToken: string; model: string; aiGatewayId?: string }) => void;
+  onDone: (cfg: KimiConfig) => void;
   onCancel?: () => void;
 }
 
 type Step =
   | "mode"
+  | "auth"
+  | "oauth"
+  | "accountPick"
   | "accountId"
   | "apiToken"
   | "routingMode"
@@ -43,10 +61,26 @@ type Step =
 
 export function Onboarding({ onDone, onCancel }: Props) {
   const theme = useTheme();
-  const [step, setStep] = useState<Step>("mode");
+  // KimiFlare Cloud is temporarily hidden (src/cloud/availability.ts): while
+  // hidden the wizard starts directly at the BYOK "connect your Cloudflare
+  // account" step instead of the Cloud-vs-Self-hosted mode picker.
+  const [step, setStep] = useState<Step>(isCloudModeAvailable() ? "mode" : "auth");
   const [modePickIdx, setModePickIdx] = useState(0);
+  // Default to "Log in with Cloudflare" when this build carries an OAuth
+  // client id; otherwise pre-select the manual token path so nobody lands on
+  // a dead button.
+  const oauthConfigured = isCloudflareLoginConfigured();
+  const [authPickIdx, setAuthPickIdx] = useState(oauthConfigured ? 0 : 1);
   const [accountId, setAccountId] = useState("");
   const [apiToken, setApiToken] = useState("");
+  // "Log in with Cloudflare" (OAuth) state.
+  const [oauthUrl, setOauthUrl] = useState<string | null>(null);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+  const [oauthPhase, setOauthPhase] = useState<"idle" | "waiting" | "accounts">("idle");
+  const [oauthState, setOauthState] = useState<CloudflareOAuthConfig | null>(null);
+  const [oauthAbort, setOauthAbort] = useState<AbortController | null>(null);
+  const [accounts, setAccounts] = useState<CloudflareAccount[]>([]);
+  const [accountPickIdx, setAccountPickIdx] = useState(0);
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [savedPath, setSavedPath] = useState<string | null>(null);
 
@@ -80,11 +114,19 @@ export function Onboarding({ onDone, onCancel }: Props) {
   useInput(
     useCallback(
       (_input, key) => {
-        if (key.escape && onCancel) {
-          onCancel();
+        if (!key.escape) return;
+        // Esc while waiting on the browser: cancel the OAuth flow and drop
+        // back to the auth-method picker instead of quitting the wizard.
+        if (step === "oauth") {
+          oauthAbort?.abort();
+          setOauthAbort(null);
+          setOauthPhase("idle");
+          setStep("auth");
+          return;
         }
+        if (onCancel) onCancel();
       },
-      [onCancel],
+      [onCancel, step, oauthAbort],
     ),
   );
 
@@ -111,7 +153,68 @@ export function Onboarding({ onDone, onCancel }: Props) {
         if (modePickIdx === 0) {
           startCloudAuth();
         } else {
+          setStep("auth");
+        }
+      }
+    },
+  );
+
+  // Arrow-key navigation on the auth-method picker (Log in with Cloudflare vs API token).
+  useInput(
+    (input, key) => {
+      if (step !== "auth") return;
+      const total = 2;
+      if (key.upArrow) {
+        setAuthPickIdx((i) => (i - 1 + total) % total);
+      } else if (key.downArrow) {
+        setAuthPickIdx((i) => (i + 1) % total);
+      } else if (key.return) {
+        if (authPickIdx === 0) {
+          startCloudflareLogin();
+        } else {
           setStep("accountId");
+        }
+      } else if (input === "m" || input === "M") {
+        setStep("accountId");
+      }
+    },
+  );
+
+  // On the OAuth waiting screen: Enter re-opens the browser, "m" falls back to manual token entry.
+  useInput(
+    (input, key) => {
+      if (step !== "oauth") return;
+      if (key.return) {
+        if (oauthError) {
+          startCloudflareLogin();
+        } else if (oauthUrl) {
+          openBrowser(oauthUrl);
+        }
+      } else if (input === "m" || input === "M") {
+        oauthAbort?.abort();
+        setOauthAbort(null);
+        setOauthPhase("idle");
+        setStep("accountId");
+      }
+    },
+  );
+
+  // Arrow-key navigation on the account picker (only shown for multi-account users).
+  useInput(
+    (_input, key) => {
+      if (step !== "accountPick") return;
+      const total = accounts.length;
+      if (total === 0) return;
+      if (key.upArrow) {
+        setAccountPickIdx((i) => (i - 1 + total) % total);
+      } else if (key.downArrow) {
+        setAccountPickIdx((i) => (i + 1) % total);
+      } else if (key.return) {
+        const picked = accounts[accountPickIdx];
+        if (picked) {
+          setAccountId(picked.id);
+          setOauthState((prev) => (prev ? { ...prev, accountName: picked.name } : prev));
+          setStep("routingMode");
         }
       }
     },
@@ -210,6 +313,8 @@ export function Onboarding({ onDone, onCancel }: Props) {
     const trimmed = value.trim();
     if (!trimmed) return;
     setAccountId(trimmed);
+    // Manual path: forget any half-finished OAuth session.
+    setOauthState(null);
     setStep("apiToken");
   };
 
@@ -241,6 +346,64 @@ export function Onboarding({ onDone, onCancel }: Props) {
     const trimmed = value.trim();
     if (!trimmed) return;
     void runProbe(trimmed);
+  };
+
+  // "Log in with Cloudflare": OAuth + PKCE via the browser. On success we hold
+  // the access token as apiToken (the rest of the app is none the wiser) and
+  // keep the refresh token in cloudflareOAuth so it can rotate silently.
+  const startCloudflareLogin = () => {
+    oauthAbort?.abort();
+    const ac = new AbortController();
+    setOauthAbort(ac);
+    setOauthError(null);
+    setOauthUrl(null);
+    setOauthPhase("waiting");
+    setStep("oauth");
+    void (async () => {
+      try {
+        const tokens = await loginWithCloudflare({
+          signal: ac.signal,
+          onAuthUrl: (url) => {
+            setOauthUrl(url);
+            openBrowser(url);
+          },
+        });
+        if (ac.signal.aborted) return;
+        setOauthPhase("accounts");
+        setApiToken(tokens.accessToken);
+        const [me, list] = await Promise.all([whoAmI(tokens.accessToken), listCloudflareAccounts(tokens.accessToken)]);
+        if (ac.signal.aborted) return;
+        const state: CloudflareOAuthConfig = {
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+          scopes: tokens.scopes,
+          clientId: CF_OAUTH_CLIENT_ID,
+          email: me?.email,
+        };
+        if (list.length === 0) {
+          setOauthError(
+            "Signed in, but this Cloudflare user has no accounts kimiflare can use. Create one at dash.cloudflare.com and try again.",
+          );
+          setOauthPhase("idle");
+          return;
+        }
+        setAccounts(list);
+        if (list.length === 1) {
+          const only = list[0]!;
+          setAccountId(only.id);
+          setOauthState({ ...state, accountName: only.name });
+          setStep("routingMode");
+        } else {
+          setOauthState(state);
+          setAccountPickIdx(0);
+          setStep("accountPick");
+        }
+      } catch (err) {
+        if (ac.signal.aborted) return;
+        setOauthPhase("idle");
+        setOauthError(err instanceof Error ? err.message : String(err));
+      }
+    })();
   };
 
   // KimiFlare Cloud device-auth flow (picked at the top-level mode step).
@@ -280,9 +443,10 @@ export function Onboarding({ onDone, onCancel }: Props) {
     }
     // Self-hosted routing:
     //   workers-ai       → nothing more to set up → confirm
+    //   cf-catalog       → paid from AI Gateway credits, no key possible → confirm
     //   unified-eligible → ask billing mode (Cloudflare credits / BYOK)
     //   BYOK-only        → straight to key entry
-    if (picked.provider === "workers-ai") {
+    if (picked.provider === "workers-ai" || routeFor(picked) === "cf-catalog") {
       setStep("confirm");
     } else if (isUnifiedEligible(picked)) {
       setStep("billingChoice");
@@ -344,6 +508,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
       apiToken,
       model,
       aiGatewayId: aiGatewayId || undefined,
+      ...(oauthState ? { cloudflareOAuth: oauthState } : {}),
       ...(cloudMode ? { cloudMode: true } : {}),
       ...(unifiedBilling ? { unifiedBilling: true } : {}),
       ...(Object.keys(providerKeyAliases).length > 0 ? { providerKeyAliases } : {}),
@@ -368,8 +533,28 @@ export function Onboarding({ onDone, onCancel }: Props) {
   const cloudModels = CLOUD_MODEL_IDS.map((id) => getModel(id)).filter((m): m is ModelEntry => !!m);
 
   // Step numbering: keep simple linear count for visible steps.
-  const visibleSteps: Step[] = ["mode", "accountId", "apiToken", "routingMode", "model", "confirm"];
-  const stepIndex = Math.max(1, visibleSteps.indexOf(step) === -1 ? 3 : visibleSteps.indexOf(step) + 1);
+  const visibleSteps: Step[] = isCloudModeAvailable()
+    ? ["mode", "auth", "routingMode", "model", "confirm"]
+    : ["auth", "routingMode", "model", "confirm"];
+  const stepAlias: Partial<Record<Step, Step>> = {
+    oauth: "auth",
+    accountPick: "auth",
+    accountId: "auth",
+    apiToken: "auth",
+    gatewayLoading: "routingMode",
+    gatewayPick: "routingMode",
+    gatewayCreate: "routingMode",
+    gatewayScopeError: "routingMode",
+    gatewayManual: "routingMode",
+    gatewayProbing: "routingMode",
+    cloudModel: "model",
+    billingChoice: "model",
+    unifiedProbe: "model",
+    keyEntry: "model",
+    cloudAuth: "mode",
+  };
+  const stepForCount = stepAlias[step] ?? step;
+  const stepIndex = Math.max(1, visibleSteps.indexOf(stepForCount) + 1);
   const totalSteps = visibleSteps.length;
 
   return (
@@ -412,9 +597,108 @@ export function Onboarding({ onDone, onCancel }: Props) {
           </>
         )}
 
+        {step === "auth" && (
+          <>
+            <Text>Connect your Cloudflare account</Text>
+            <Text color={theme.info.color}>
+              Use ↑/↓ to navigate, Enter to select.
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              <Text color={authPickIdx === 0 ? theme.palette.primary : undefined}>
+                {authPickIdx === 0 ? "› " : "  "}
+                Log in with Cloudflare  {oauthConfigured ? "(recommended)" : "(not configured in this build)"}
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Opens your browser. Cloudflare asks you to approve kimiflare once — no API token to create, no Account ID to copy.
+              </Text>
+              <Text> </Text>
+              <Text color={authPickIdx === 1 ? theme.palette.primary : undefined}>
+                {authPickIdx === 1 ? "› " : "  "}
+                Paste an API token
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Create a token at dash.cloudflare.com/profile/api-tokens (Workers AI:Read, AI Gateway:Read/Edit), then enter your Account ID + token.
+              </Text>
+            </Box>
+            <Box marginTop={1}>
+              <Text color={theme.info.color} dimColor>
+                Everything runs in your own Cloudflare account — kimiflare never sees your credentials on a server.
+              </Text>
+            </Box>
+          </>
+        )}
+
+        {step === "oauth" && (
+          <Box flexDirection="column">
+            <Text bold color={theme.accent}>
+              Log in with Cloudflare
+            </Text>
+            {oauthError ? (
+              <>
+                <Box marginTop={1}>
+                  <Text color={theme.error}>{oauthError}</Text>
+                </Box>
+                <Box marginTop={1}>
+                  <Text color={theme.info.color}>
+                    Press <Text bold color={theme.accent}>Enter</Text> to try again · <Text bold color={theme.accent}>m</Text> to paste an API token instead · <Text bold color={theme.accent}>Esc</Text> to go back
+                  </Text>
+                </Box>
+              </>
+            ) : oauthPhase === "accounts" ? (
+              <Box marginTop={1}>
+                <Text color={theme.info.color}>✓ Approved. Looking up your Cloudflare accounts…</Text>
+              </Box>
+            ) : (
+              <>
+                <Box marginTop={1}>
+                  <Text color={theme.info.color}>
+                    {oauthUrl ? "Waiting for you to approve kimiflare in your browser…" : "Starting sign-in…"}
+                  </Text>
+                </Box>
+                {oauthUrl && (
+                  <Box flexDirection="column" marginTop={1}>
+                    <Text color={theme.info.color}>
+                      If the browser didn't open, press <Text bold color={theme.accent}>Enter</Text> to open it again, or visit:
+                    </Text>
+                    <Text color={theme.info.color} dimColor wrap="wrap">
+                      {oauthUrl}
+                    </Text>
+                  </Box>
+                )}
+                <Box marginTop={1}>
+                  <Text color={theme.info.color} dimColor>
+                    <Text bold>m</Text> paste an API token instead · <Text bold>Esc</Text> go back
+                  </Text>
+                </Box>
+              </>
+            )}
+          </Box>
+        )}
+
+        {step === "accountPick" && (
+          <>
+            <Text>Which Cloudflare account should kimiflare use?</Text>
+            <Text color={theme.info.color}>
+              Use ↑/↓ to navigate, Enter to select.
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              {accounts.map((acct, i) => (
+                <Text key={acct.id} color={i === accountPickIdx ? theme.palette.primary : undefined}>
+                  {i === accountPickIdx ? "› " : "  "}
+                  {acct.name}
+                  <Text color={theme.info.color} dimColor>{"  "}{acct.id}</Text>
+                </Text>
+              ))}
+            </Box>
+          </>
+        )}
+
         {step === "accountId" && (
           <>
             <Text>Enter your Cloudflare Account ID</Text>
+            <Text color={theme.info.color}>
+              Find it in the dashboard sidebar or the URL: dash.cloudflare.com/&lt;account-id&gt;
+            </Text>
             <Box marginTop={1}>
               <Text color={theme.palette.primary}>› </Text>
               <CustomTextInput
@@ -678,10 +962,20 @@ export function Onboarding({ onDone, onCancel }: Props) {
               borderColor={theme.info.color}
               paddingX={1}
             >
-              {!cloudMode && (
+              {!cloudMode && oauthState && (
+                <>
+                  <Text color={theme.info.color}>
+                    Cloudflare: signed in{oauthState.email ? ` as ${oauthState.email}` : ""} (Log in with Cloudflare)
+                  </Text>
+                  <Text color={theme.info.color}>
+                    Account: {oauthState.accountName ? `${oauthState.accountName}  ` : ""}{accountId}
+                  </Text>
+                </>
+              )}
+              {!cloudMode && !oauthState && (
                 <>
                   <Text color={theme.info.color}>Account ID: {accountId}</Text>
-                  <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
+                  <Text color={theme.info.color}>API Token: {"•".repeat(Math.min(apiToken.length, 40))}</Text>
                 </>
               )}
               {!cloudMode && <Text color={theme.info.color}>Model: {model}</Text>}

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -66,6 +66,7 @@ import { HOOK_EVENTS } from "../hooks/types.js";
 import type { AbortScope } from "../util/abort-scope.js";
 import type { CustomCommand } from "../commands/types.js";
 import { buildReport, sendReport } from "../cloud/report.js";
+import { isCloudModeAvailable, CLOUD_UNAVAILABLE_NOTICE } from "../cloud/availability.js";
 import { checkForUpdate } from "../util/update-check.js";
 import { getAppVersion } from "../util/version.js";
 import {
@@ -1516,27 +1517,50 @@ const handleReport: Handler = (ctx, rest) => {
 };
 
 const handleLogout: Handler = (ctx) => {
+  // "Log in with Cloudflare" sessions: revoke the refresh token so the grant
+  // disappears from the user's Cloudflare authorizations too (best effort).
+  const oauth = ctx.cfg?.cloudflareOAuth;
+  if (oauth?.refreshToken) {
+    void import("../cloud/cloudflare-oauth.js").then(({ revokeCloudflareToken }) =>
+      revokeCloudflareToken(oauth.refreshToken!, oauth.clientId),
+    );
+  }
   unlink(configPath()).catch(() => {});
   ctx.setEvents((e) => [
     ...e,
-    { kind: "info", key: ctx.mkKey(), text: `credentials cleared from ${configPath()}` },
+    {
+      kind: "info",
+      key: ctx.mkKey(),
+      text: oauth
+        ? `signed out of Cloudflare and cleared credentials from ${configPath()}`
+        : `credentials cleared from ${configPath()}`,
+    },
   ]);
   ctx.setCfg(null);
   return true;
 };
 
+// /upgrade, /topup and /manage only exist for KimiFlare Cloud, which is
+// temporarily hidden (src/cloud/availability.ts). While hidden they print a
+// short notice instead of reaching into the (still present) billing client.
+const cloudCommandGate = (ctx: SlashContext): boolean => {
+  if (isCloudModeAvailable()) return true;
+  ctx.setEvents((e) => [...e, { kind: "info", key: ctx.mkKey(), text: CLOUD_UNAVAILABLE_NOTICE }]);
+  return false;
+};
+
 const handleUpgrade: Handler = (ctx) => {
-  void ctx.upgrade();
+  if (cloudCommandGate(ctx)) void ctx.upgrade();
   return true;
 };
 
 const handleTopup: Handler = (ctx) => {
-  void ctx.topup();
+  if (cloudCommandGate(ctx)) void ctx.topup();
   return true;
 };
 
 const handleManage: Handler = (ctx) => {
-  void ctx.manageMembership();
+  if (cloudCommandGate(ctx)) void ctx.manageMembership();
   return true;
 };
 

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -87,7 +87,7 @@ export function humanizeCloudflareError(err: KimiApiError): string {
   if (httpStatus === 401) {
     const codeStr = code !== undefined ? ` (code: ${code})` : "";
     return (
-      `Authentication required${codeStr}. Please check your API token or run \`kimiflare auth cloud\` if using cloud mode.`
+      `Authentication required${codeStr}. Your Cloudflare credentials were rejected — run \`kimiflare auth cloudflare\` to log in with Cloudflare again, or check your API token.`
     );
   }
 


### PR DESCRIPTION
## What

**1. Onboarding is BYOK-only, and the default path is "Log in with Cloudflare"**

New first step — *Connect your Cloudflare account*:

- **Log in with Cloudflare (recommended)** — OAuth 2.0 + PKCE against Cloudflare's [self-managed OAuth client](https://developers.cloudflare.com/fundamentals/oauth/) feature (same `dash.cloudflare.com/oauth2/*` server `wrangler login` uses, our own client id). The CLI starts a loopback callback server on `127.0.0.1:8978`, opens the consent page ("kimiflare wants permission to …"), exchanges the code, calls `GET /user` + `GET /accounts`, auto-selects the account (picker for multi-account users), and stores the access token as `apiToken` (so nothing downstream changes) plus a `cloudflareOAuth` block. Tokens rotate silently: on `loadConfig()`, a timer in the TUI before each expiry, and an interval in `kimiflare serve`. `/logout` revokes the grant. New `kimiflare auth cloudflare [--account <id>] [--no-browser]`.
- **Paste an API token** — the old Account ID + token path, unchanged; env `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_API_TOKEN` still override everything.

Scopes requested (dot-delimited ids, verified against `GET /oauth/scopes`): `user-details.read account-settings.read ai.read ai.write aig.read aig.write aig.run secrets-store.read secrets-store.write` (+ `offline_access`).

**2. KimiFlare Cloud (managed service) is temporarily hidden — nothing deleted**

`src/cloud/availability.ts` (`CLOUD_MODE_ENABLED = false`) gates every entry point: the Cloud option in the wizard, the "Start free with Kimiflare Cloud" billing-chooser item, `--cloud`, `KIMIFLARE_CLOUD=1`, a persisted `cloudMode: true` (→ BYOK onboarding), `kimiflare auth cloud`, `kimiflare usage`, and `/upgrade` `/topup` `/manage` (print a one-line notice). Flip the constant to bring it back.

**3. Kimi K3 actually works now (verified live)**

The previous entry assumed K3 was a BYOK provider on `gateway.ai.cloudflare.com/…/compat` with a Moonshot key. It isn't: `moonshotai/kimi-k3` is a **third-party model in Cloudflare's model catalog, paid from AI Gateway credits (Unified Billing)** via `POST /accounts/{id}/ai/v1/chat/completions` (+ `cf-aig-gateway-id`). New `routeFor()` → `"cf-catalog"` sends it there with only the Cloudflare token; no key, no mandatory gateway. Also: `supports.temperature: false` (K3 returns **400 "invalid temperature: only 1 is allowed"** for anything else — the old entry sent `0.2` and could never have worked), pricing `$3 / $0.30 cached / $15` per M, 1,048,576 ctx.

Live checks (5 tiny requests, ≈$0.005, all visible in the `kimiflare` gateway logs): non-streaming ✓, streaming with `reasoning_content` + `tool_calls` + usage ✓, `reasoning_effort` low/medium ✓, temperature ≠1 → 400 ✓. Note: this endpoint returns no `cf-aig-log-id` header, so per-turn gateway log lookup isn't available for K3 turns.

## OAuth client status — all done ✅

- [x] `kimiflare` OAuth client registered (2026-08-19) in the account that owns kimiflare.com — client id `2300cf3ff5499cdc69cb52c6b66504b8`, public/PKCE, grants `authorization_code` + `refresh_token`, redirect `http://localhost:8978/oauth/callback`, the 9 scopes above (+ `offline_access`). Baked into `CF_OAUTH_CLIENT_ID`.
- [x] Domain-verification TXT record published on `kimiflare.com` (`cloudflare_oauth_client_publisher=88913d621ea51f8b2937995a166d4c05`) — status **Verified**.
- [x] Promoted from Private to **Public** — any Cloudflare user can log in; consent screen shows the verified-publisher shield.
- [x] End-to-end: `kimiflare auth cloudflare` → consent screen ("kimiflare wants to access your account", 9 permissions, account pre-selected) → loopback callback → PKCE exchange → `/user` + `/accounts` → config patched. The resulting token lists gateways (`aig.read`), runs `/compat` inference on the authenticated gateway (`aig.run`), Workers AI direct + K3 via the unified endpoint (`ai.read`), Secrets Store; a print-mode K3 turn through the real app returned `pong`.

Two fixes fell out of the E2E run (second commit):
- `probeGateway()` now uses the unified `api.cloudflare.com/…/ai/run/{model}` + `cf-aig-gateway-id` path — the gateway host's provider-native `workers-ai/…` route 401s for OAuth tokens even with `aig.run` + `ai.read`. Missing gateway / bad token now surface instead of being swallowed as "ok".
- **Pre-existing bug on `main`:** `loadConfig()` initialised `envModel` to `DEFAULT_MODEL`, so `envModel ?? parsed.model` never read the persisted model — every launch silently reset `/model` choices to `kimi-k2.6`. `KIMI_MODEL` is now an override only; test added.

## Tests

- `src/cloud/cloudflare-oauth.test.ts` — PKCE, authorize URL (S256, `offline_access`, no legacy colon scopes), full loopback flow, state mismatch, `access_denied`, abort, refresh (rotating token), token-endpoint errors, unconfigured client.
- `src/cloud/cloudflare-session.test.ts` — `loadConfig()` passes `cloudflareOAuth` through, refreshes an expiring token and persists the rotated refresh token without clobbering other keys, env token overrides the session.
- `src/cloud/availability.test.tsx` — wizard renders "Connect your Cloudflare account" (never "KimiFlare Cloud"), billing chooser has no Cloud item, persisted `cloudMode:true` / `KIMIFLARE_CLOUD=1` are ignored.
- Updated K3 client/registry tests (unified REST URL, `cf-aig-gateway-id`, no BYOK headers, no `temperature`, works without a gateway).

`npm test`: 819/821 pass — the 2 failures (`status.test.ts` `$` formatting, `theme-contrast.test.ts`) are pre-existing on `main`. `tsc --noEmit` clean apart from the pre-existing optional `isolated-vm` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


