### PR TITLE
feat: custom OpenAI-compatible gateway endpoint (KIMIFLARE_BASE_URL / KIMIFLARE_API_KEY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,30 @@ then enter it with your Account ID in the wizard, or set `CLOUDFLARE_ACCOUNT_ID`
 
 Once configured, `/cost` shows the Gateway-confirmed totals, cache hit ratio, per-feature breakdown, and direct dashboard links to each request log. `/gateway status` shows the current TTL, skip-cache flag, metadata tags, and live cache-hit ratio.
 
+### Custom gateway endpoint
+
+Point every model call at your own OpenAI-compatible endpoint instead of Cloudflare — useful when a
+host application (CI, an agents platform, a container) fronts AI Gateway with its own broker and
+doesn't want to hand kimiflare a raw Cloudflare token:
+
+```sh
+export KIMIFLARE_BASE_URL="https://your-broker.example.com/v1"  # /chat/completions is appended
+export KIMIFLARE_API_KEY="<bearer for that endpoint>"           # optional; header omitted if unset
+kimiflare -p "..."        # or --mode rpc — no Cloudflare login, token, or account id needed
+```
+
+The same pair can be persisted in `~/.config/kimiflare/config.json` as `baseUrl` / `apiKey`
+(env vars win over the file, field by field). When a base URL is configured it takes precedence
+over **every** Cloudflare path:
+
+- Requests go to `<baseUrl>/chat/completions` with `Authorization: Bearer $KIMIFLARE_API_KEY`
+  (no `Authorization` header at all when the key is unset — e.g. a local llama.cpp/Ollama server).
+- No `cf-aig-*` headers, no BYOK / Unified Billing logic, no account-id URLs, and no Cloudflare
+  token validation or OAuth refresh — Cloudflare credentials become entirely optional.
+- Model ids pass through in the request body unchanged; your endpoint owns provider dispatch.
+- Cloudflare-only extras (AI Gateway `/cost` reconciliation, memory embeddings via Workers AI)
+  still need a Cloudflare account — leave them disabled when running endpoint-only.
+
 ### Model
 
 KimiFlare runs on **Kimi K2.7** via Cloudflare Workers AI — no API key needed beyond your Cloudflare token:
@@ -163,7 +187,10 @@ session.dispose();
 
 #### SDK Authentication
 
-The SDK needs a Cloudflare **Account ID**, **API Token**, and AI Gateway ID. Credentials are resolved in this priority order:
+The SDK needs a Cloudflare **Account ID**, **API Token**, and AI Gateway ID — or a
+[custom gateway endpoint](#custom-gateway-endpoint) (`baseUrl` / `apiKey` in `config`, or
+`KIMIFLARE_BASE_URL` / `KIMIFLARE_API_KEY`), in which case no Cloudflare credentials are required.
+Credentials are resolved in this priority order:
 
 1. **Explicit `config` object** (recommended for apps)
 2. **Environment variables**: `CLOUDFLARE_ACCOUNT_ID` / `CF_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` / `CF_API_TOKEN`
@@ -190,6 +217,10 @@ If you need process isolation or a non-Node consumer, run KimiFlare in JSONL-ove
 ```sh
 node bin/kimiflare.mjs --mode rpc
 ```
+
+RPC mode also runs against a [custom gateway endpoint](#custom-gateway-endpoint) alone: set
+`KIMIFLARE_BASE_URL` + `KIMIFLARE_API_KEY` on the subprocess and no Cloudflare credentials are
+needed — ideal for host apps that broker model access themselves.
 
 ```ts
 import { spawn } from "node:child_process";

--- a/docs/login-with-cloudflare.md
+++ b/docs/login-with-cloudflare.md
@@ -156,3 +156,12 @@ kimiflare auth cloudflare --account <id> --no-browser
 Manual tokens keep working: pick **Paste an API token** in onboarding, or set
 `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` (env credentials override a
 stored OAuth session).
+
+## Bypassing Cloudflare auth entirely
+
+`KIMIFLARE_BASE_URL` (+ optional `KIMIFLARE_API_KEY`) routes every model call
+to a custom OpenAI-compatible endpoint and skips this whole page: no OAuth
+session, no token refresh, no account-id lookups, no `cf-aig-*` headers. Host
+apps that broker AI Gateway access themselves use it to avoid handing the
+kimiflare process a raw Cloudflare token. See "Custom gateway endpoint" in the
+README and `src/agent/custom-endpoint.ts`.

--- a/src/agent/client.custom-endpoint.test.ts
+++ b/src/agent/client.custom-endpoint.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Custom OpenAI-compatible endpoint routing tests for runKimi.
+ *
+ * A host application (e.g. an agents platform running kimiflare inside a
+ * container) points the CLI at its own gateway/broker with
+ * KIMIFLARE_BASE_URL + KIMIFLARE_API_KEY instead of handing the process a raw
+ * Cloudflare token. These tests pin the contract:
+ *
+ *   1. Requests go to `<baseUrl>/chat/completions` with
+ *      `Authorization: Bearer <apiKey>` — and nothing else auth-wise: no
+ *      cf-aig-authorization, no cf-aig-byok-alias, no cf-aig-* gateway
+ *      headers, no Cloudflare token fallback.
+ *   2. The custom endpoint wins over every Cloudflare path (gateway,
+ *      cf-catalog, direct Workers AI, cloud mode) even when those are
+ *      configured too.
+ *   3. Model ids pass through in the body unchanged — no workers-ai/
+ *      prefixing, no Cloudflare id-shape validation.
+ *   4. Works with completely empty Cloudflare credentials.
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import { runKimi } from "./client.js";
+
+const ENV_KEYS = ["KIMIFLARE_BASE_URL", "KIMIFLARE_API_KEY"] as const;
+
+describe("runKimi: custom OpenAI-compatible endpoint", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let lastRequest: Request | null = null;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  before(() => {
+    for (const k of ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      lastRequest = new Request(input, init);
+      return new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+  });
+  after(() => {
+    globalThis.fetch = originalFetch;
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+  beforeEach(() => {
+    lastRequest = null;
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  it("routes to <baseUrl>/chat/completions with the custom bearer and no Cloudflare credentials", async () => {
+    for await (const _ of runKimi({
+      accountId: "",
+      apiToken: "",
+      model: "@cf/moonshotai/kimi-k2.6",
+      messages: [{ role: "user", content: "hi" }],
+      customEndpoint: { baseUrl: "https://aig.example.com/v1", apiKey: "broker-key" },
+    })) {
+      /* drain */
+    }
+    assert.ok(lastRequest);
+    assert.strictEqual(lastRequest!.url, "https://aig.example.com/v1/chat/completions");
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer broker-key");
+    const body = JSON.parse(await lastRequest!.text()) as Record<string, unknown>;
+    // Model id passes through unchanged — no workers-ai/ prefix.
+    assert.strictEqual(body.model, "@cf/moonshotai/kimi-k2.6");
+    assert.deepStrictEqual(body.stream_options, { include_usage: true });
+  });
+
+  it("wins over gateway / BYOK / unified-billing config and sends no cf-aig-* headers", async () => {
+    for await (const _ of runKimi({
+      accountId: "acct",
+      apiToken: "cf-token",
+      model: "anthropic/claude-haiku-4-5",
+      messages: [{ role: "user", content: "hi" }],
+      gateway: { id: "gw", cacheTtl: 60, metadata: { feature: "chat" } },
+      providerKeys: { anthropic: "sk-ant-should-not-leak" },
+      providerKeyAliases: { anthropic: "alias-should-not-leak" },
+      unifiedBilling: true,
+      customEndpoint: { baseUrl: "https://aig.example.com/v1", apiKey: "broker-key" },
+    })) {
+      /* drain */
+    }
+    assert.ok(lastRequest);
+    assert.strictEqual(lastRequest!.url, "https://aig.example.com/v1/chat/completions");
+    // The broker bearer replaces the Cloudflare token — never both.
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer broker-key");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-authorization"), null);
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-byok-alias"), null);
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-gateway-id"), null);
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-cache-ttl"), null);
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-metadata"), null);
+  });
+
+  it("accepts model ids the Cloudflare paths would reject (host gateway owns dispatch)", async () => {
+    for await (const _ of runKimi({
+      accountId: "",
+      apiToken: "",
+      model: "my-broker-alias", // no @cf/ or provider/ shape
+      messages: [{ role: "user", content: "hi" }],
+      customEndpoint: { baseUrl: "https://aig.example.com/v1", apiKey: "broker-key" },
+    })) {
+      /* drain */
+    }
+    const body = JSON.parse(await lastRequest!.text()) as Record<string, unknown>;
+    assert.strictEqual(body.model, "my-broker-alias");
+  });
+
+  it("omits the Authorization header entirely when no apiKey is configured", async () => {
+    for await (const _ of runKimi({
+      accountId: "",
+      apiToken: "",
+      model: "@cf/moonshotai/kimi-k2.6",
+      messages: [{ role: "user", content: "hi" }],
+      customEndpoint: { baseUrl: "http://127.0.0.1:11434/v1" },
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), null);
+  });
+
+  it("does not double /chat/completions when the base already includes it", async () => {
+    for await (const _ of runKimi({
+      accountId: "",
+      apiToken: "",
+      model: "@cf/moonshotai/kimi-k2.6",
+      messages: [{ role: "user", content: "hi" }],
+      customEndpoint: { baseUrl: "https://aig.example.com/v1/chat/completions", apiKey: "k" },
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(lastRequest!.url, "https://aig.example.com/v1/chat/completions");
+  });
+
+  it("falls back to KIMIFLARE_BASE_URL / KIMIFLARE_API_KEY from the environment", async () => {
+    process.env.KIMIFLARE_BASE_URL = "https://env.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "env-key";
+    for await (const _ of runKimi({
+      accountId: "acct",
+      apiToken: "cf-token",
+      model: "@cf/moonshotai/kimi-k2.6",
+      messages: [{ role: "user", content: "hi" }],
+      gateway: { id: "gw" },
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(lastRequest!.url, "https://env.example.com/v1/chat/completions");
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer env-key");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-gateway-id"), null);
+  });
+
+  it("wins over cloud mode and does not demand a cloud token", async () => {
+    // Without a custom endpoint this combination throws before any fetch.
+    for await (const _ of runKimi({
+      accountId: "",
+      apiToken: "",
+      model: "moonshotai/kimi-k3",
+      messages: [{ role: "user", content: "hi" }],
+      cloudMode: true,
+      customEndpoint: { baseUrl: "https://aig.example.com/v1", apiKey: "broker-key" },
+    })) {
+      /* drain */
+    }
+    assert.strictEqual(lastRequest!.url, "https://aig.example.com/v1/chat/completions");
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer broker-key");
+    // Body still carries the model verbatim (cloud shape would omit it).
+    const body = JSON.parse(await lastRequest!.text()) as Record<string, unknown>;
+    assert.strictEqual(body.model, "moonshotai/kimi-k3");
+  });
+
+  it("rejects an empty model id", async () => {
+    await assert.rejects(async () => {
+      for await (const _ of runKimi({
+        accountId: "",
+        apiToken: "",
+        model: "",
+        messages: [{ role: "user", content: "hi" }],
+        customEndpoint: { baseUrl: "https://aig.example.com/v1", apiKey: "k" },
+      })) {
+        /* drain */
+      }
+    }, /Invalid model ID/);
+  });
+});

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -14,6 +14,7 @@ import {
 } from "../util/llm-dump.js";
 import { getModelOrInfer, isUnifiedEligible, routeFor, type ModelProvider } from "../models/registry.js";
 import { DEFAULT_MODEL, DEFAULT_CLOUD_MODEL } from "../config.js";
+import { resolveCustomEndpoint, customChatCompletionsUrl, type CustomEndpoint } from "./custom-endpoint.js";
 
 export type KimiEvent =
   | { type: "gateway_meta"; meta: GatewayMeta }
@@ -57,6 +58,14 @@ export interface RunKimiOpts {
   /** Once the first byte arrives, tighten the idle timeout to this value.
    *  Default 30000 — a live stream stalling mid-flight should surface fast. */
   postFirstByteIdleTimeoutMs?: number;
+  /**
+   * Custom OpenAI-compatible endpoint (see src/agent/custom-endpoint.ts).
+   * When set — or when KIMIFLARE_BASE_URL is in the environment — the request
+   * goes to `<baseUrl>/chat/completions` with `Authorization: Bearer <apiKey>`
+   * and every Cloudflare path (Workers AI, AI Gateway, cf-catalog, cloud
+   * mode) is bypassed. Model ids pass through in the body unchanged.
+   */
+  customEndpoint?: CustomEndpoint;
 }
 
 export interface AiGatewayOptions {
@@ -92,12 +101,16 @@ function isRetryable(err: KimiApiError, attempt: number): boolean {
 }
 
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
-  if (opts.cloudMode && !opts.cloudToken) {
+  // Custom endpoint wins over everything, including cloud mode. The env
+  // fallback means side-call paths (memory extraction, summarization, …)
+  // that build RunKimiOpts from raw accountId/apiToken are rerouted too.
+  const customEndpoint = opts.customEndpoint ?? resolveCustomEndpoint();
+  if (!customEndpoint && opts.cloudMode && !opts.cloudToken) {
     throw new KimiApiError("kimiflare: cloud mode requires a cloud token. Run `kimiflare auth cloud` to authenticate.", undefined, 401);
   }
   const requestId = opts.requestId ?? crypto.randomUUID();
-  const { url, headers: gatewayHeaders } = buildKimiRequestTarget(opts);
-  const isCloudEndpoint = url.startsWith("https://api.kimiflare.com");
+  const { url, headers: gatewayHeaders } = buildKimiRequestTarget(opts, customEndpoint);
+  const isCloudEndpoint = !customEndpoint && url.startsWith("https://api.kimiflare.com");
   // Per-model capability gates. Some providers reject params they don't
   // support — gpt-5/gpt-5-mini and claude-opus-4-7 reject any non-default
   // `temperature`; Groq's llama-3.3 rejects `reasoning_effort`. We look up the
@@ -111,8 +124,11 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   // (e.g. "workers-ai/@cf/moonshotai/kimi-k2.7-code"). Cloud mode uses its own
   // shape and ignores this field. The direct Workers AI path (api.cloudflare.com)
   // also ignores the body model field because the model is already in the URL.
-  const isDirectWorkersAi = url.includes("/ai/run/");
-  const compatModel = entry.provider === "workers-ai" ? `workers-ai/${opts.model}` : opts.model;
+  const isDirectWorkersAi = !customEndpoint && url.includes("/ai/run/");
+  // Custom endpoints receive the model id verbatim — the host's gateway owns
+  // provider dispatch, so no workers-ai/ prefixing.
+  const compatModel =
+    !customEndpoint && entry.provider === "workers-ai" ? `workers-ai/${opts.model}` : opts.model;
 
   const body: Record<string, unknown> = {
     messages: sanitizeMessagesForApi(opts.messages),
@@ -176,8 +192,13 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     let res: Response;
     try {
+      // For custom endpoints the bearer (if any) rides in gatewayHeaders —
+      // never fall back to the Cloudflare/cloud token, and send no
+      // Authorization header at all when no apiKey is configured.
       const headers: Record<string, string> = {
-        Authorization: `Bearer ${opts.cloudMode && opts.cloudToken ? opts.cloudToken : opts.apiToken}`,
+        ...(customEndpoint
+          ? {}
+          : { Authorization: `Bearer ${opts.cloudMode && opts.cloudToken ? opts.cloudToken : opts.apiToken}` }),
         "Content-Type": "application/json",
         "User-Agent": getUserAgent(),
         ...gatewayHeaders,
@@ -237,10 +258,17 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
         try { return getModelOrInfer(opts.model).provider; } catch { return null; }
       })();
       const isProviderAuthError =
+        !customEndpoint &&
         (res.status === 401 || res.status === 403) &&
         modelProvider !== null &&
         modelProvider !== "workers-ai";
-      const wrappedMsg = isProviderAuthError
+      const wrappedMsg = customEndpoint && (res.status === 401 || res.status === 403)
+        ? [
+            `${opts.model} rejected the request (HTTP ${res.status}): ${msg || "authentication failed"}.`,
+            ``,
+            `Check that KIMIFLARE_API_KEY (or \`apiKey\` in config) matches what ${customEndpoint.baseUrl} expects.`,
+          ].join("\n")
+        : isProviderAuthError
         ? [
             `${opts.model} rejected the request (HTTP ${res.status}): ${msg || "authentication failed"}.`,
             ``,
@@ -286,7 +314,8 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
 
     // Client-side fallback: report usage to cloud worker for reconciliation.
     // Only applies to Workers AI models (api.kimiflare.com handles those bills).
-    if (opts.cloudMode && lastUsage && opts.cloudToken && getModelOrInfer(opts.model).provider === "workers-ai") {
+    // Never fires for custom endpoints — the host's gateway does its own metering.
+    if (!customEndpoint && opts.cloudMode && lastUsage && opts.cloudToken && getModelOrInfer(opts.model).provider === "workers-ai") {
       const reportUrl = "https://api.kimiflare.com/v1/usage/report";
       const reportHeaders: Record<string, string> = {
         Authorization: `Bearer ${opts.cloudToken}`,
@@ -394,7 +423,23 @@ function gatewayHeadersFor(opts: RunKimiOpts): Record<string, string> {
   return headers;
 }
 
-function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Record<string, string> } {
+function buildKimiRequestTarget(
+  opts: RunKimiOpts,
+  customEndpoint: CustomEndpoint | null,
+): { url: string; headers: Record<string, string> } {
+  // Custom OpenAI-compatible endpoint: the host app owns routing and auth,
+  // so every Cloudflare path below is bypassed — no account-id URLs, no
+  // cf-aig-* headers, no BYOK / Unified Billing logic. The model id only
+  // rides in the JSON body on this path (never the URL), so the strict
+  // Cloudflare id shapes don't apply: any non-empty id passes through.
+  if (customEndpoint) {
+    if (!opts.model) throw new KimiApiError(`Invalid model ID: ${opts.model}`, 400);
+    return {
+      url: customChatCompletionsUrl(customEndpoint.baseUrl),
+      headers: customEndpoint.apiKey ? { Authorization: `Bearer ${customEndpoint.apiKey}` } : {},
+    };
+  }
+
   validateModelId(opts.model);
 
   if (opts.cloudMode) {

--- a/src/agent/custom-endpoint.test.ts
+++ b/src/agent/custom-endpoint.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach, after } from "node:test";
+import assert from "node:assert";
+import { resolveCustomEndpoint, customChatCompletionsUrl } from "./custom-endpoint.js";
+
+const ENV_KEYS = ["KIMIFLARE_BASE_URL", "KIMIFLARE_API_KEY"] as const;
+const saved: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) saved[k] = process.env[k];
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+}
+
+describe("resolveCustomEndpoint", () => {
+  beforeEach(clearEnv);
+  after(restoreEnv);
+
+  it("returns null when neither env nor config carries a base URL", () => {
+    assert.strictEqual(resolveCustomEndpoint(), null);
+    assert.strictEqual(resolveCustomEndpoint({}), null);
+    assert.strictEqual(resolveCustomEndpoint(null), null);
+  });
+
+  it("an API key alone does not activate custom routing", () => {
+    process.env.KIMIFLARE_API_KEY = "sk-broker";
+    assert.strictEqual(resolveCustomEndpoint(), null);
+    assert.strictEqual(resolveCustomEndpoint({ apiKey: "sk-config" }), null);
+  });
+
+  it("resolves from env vars", () => {
+    process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "sk-broker";
+    assert.deepStrictEqual(resolveCustomEndpoint(), {
+      baseUrl: "https://aig.example.com/v1",
+      apiKey: "sk-broker",
+    });
+  });
+
+  it("resolves from config fields when env is unset", () => {
+    assert.deepStrictEqual(
+      resolveCustomEndpoint({ baseUrl: "https://cfg.example.com/v1", apiKey: "sk-config" }),
+      { baseUrl: "https://cfg.example.com/v1", apiKey: "sk-config" },
+    );
+  });
+
+  it("env wins over config, field by field", () => {
+    process.env.KIMIFLARE_BASE_URL = "https://env.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "sk-env";
+    assert.deepStrictEqual(
+      resolveCustomEndpoint({ baseUrl: "https://cfg.example.com/v1", apiKey: "sk-config" }),
+      { baseUrl: "https://env.example.com/v1", apiKey: "sk-env" },
+    );
+    // Mixed: base URL from env, key from config.
+    delete process.env.KIMIFLARE_API_KEY;
+    assert.deepStrictEqual(
+      resolveCustomEndpoint({ apiKey: "sk-config" }),
+      { baseUrl: "https://env.example.com/v1", apiKey: "sk-config" },
+    );
+  });
+
+  it("treats blank values as unset", () => {
+    process.env.KIMIFLARE_BASE_URL = "   ";
+    assert.strictEqual(resolveCustomEndpoint(), null);
+    process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "";
+    assert.deepStrictEqual(resolveCustomEndpoint(), { baseUrl: "https://aig.example.com/v1" });
+  });
+});
+
+describe("customChatCompletionsUrl", () => {
+  it("appends /chat/completions to a bare base", () => {
+    assert.strictEqual(
+      customChatCompletionsUrl("https://aig.example.com/v1"),
+      "https://aig.example.com/v1/chat/completions",
+    );
+  });
+
+  it("trims trailing slashes before appending", () => {
+    assert.strictEqual(
+      customChatCompletionsUrl("https://aig.example.com/v1///"),
+      "https://aig.example.com/v1/chat/completions",
+    );
+  });
+
+  it("leaves a base that already ends in /chat/completions alone", () => {
+    assert.strictEqual(
+      customChatCompletionsUrl("https://aig.example.com/v1/chat/completions"),
+      "https://aig.example.com/v1/chat/completions",
+    );
+    assert.strictEqual(
+      customChatCompletionsUrl("https://aig.example.com/v1/chat/completions/"),
+      "https://aig.example.com/v1/chat/completions",
+    );
+  });
+});

--- a/src/agent/custom-endpoint.ts
+++ b/src/agent/custom-endpoint.ts
@@ -1,0 +1,64 @@
+/**
+ * Custom OpenAI-compatible endpoint routing.
+ *
+ * When `KIMIFLARE_BASE_URL` is set (or `baseUrl` in config), every model call
+ * is sent to `<baseUrl>/chat/completions` with
+ * `Authorization: Bearer <KIMIFLARE_API_KEY>` — and every Cloudflare path is
+ * bypassed: no account-id URLs, no cf-aig-* headers, no BYOK / Unified
+ * Billing logic, no Cloudflare token, and no whoami-style preflights.
+ *
+ * This is how a host application (e.g. an agents platform running kimiflare
+ * inside a container) points the CLI at its own gateway/broker instead of
+ * handing the process a raw Cloudflare token. The broker terminates the
+ * bearer it issued and forwards to AI Gateway (or any OpenAI-compatible
+ * upstream) with credentials that never enter this process.
+ *
+ * Precedence (per field): env var > config field. When a custom endpoint is
+ * active it wins over cloud mode, the AI Gateway Universal Endpoint, the
+ * cf-catalog path, and the direct Workers AI path. Model ids pass through to
+ * the body unchanged — no `workers-ai/` prefixing, no Cloudflare id-shape
+ * validation.
+ */
+
+export interface CustomEndpoint {
+  /** OpenAI-compatible base URL. `/chat/completions` is appended unless the URL already ends with it. */
+  baseUrl: string;
+  /** Bearer sent as `Authorization` to `baseUrl`. Omitted entirely when unset (unauthenticated local gateways). */
+  apiKey?: string;
+}
+
+/** Config fields a custom endpoint can be persisted under (see `KimiConfig`). */
+export interface CustomEndpointConfigFields {
+  baseUrl?: string;
+  apiKey?: string;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Resolve the custom endpoint, if one is configured. Env vars win over
+ * config fields, field by field (same rule `loadConfig()` applies to every
+ * other setting). Returns null when no base URL is configured anywhere —
+ * an API key on its own does not activate custom routing.
+ */
+export function resolveCustomEndpoint(
+  config?: CustomEndpointConfigFields | null,
+): CustomEndpoint | null {
+  const baseUrl = nonEmpty(process.env.KIMIFLARE_BASE_URL) ?? nonEmpty(config?.baseUrl);
+  if (!baseUrl) return null;
+  const apiKey = nonEmpty(process.env.KIMIFLARE_API_KEY) ?? nonEmpty(config?.apiKey);
+  return { baseUrl, ...(apiKey ? { apiKey } : {}) };
+}
+
+/**
+ * Build the chat-completions URL for a custom base. Lenient about how the
+ * base was written: trailing slashes are trimmed, and a base that already
+ * ends in `/chat/completions` is used as-is.
+ */
+export function customChatCompletionsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return trimmed.endsWith("/chat/completions") ? trimmed : `${trimmed}/chat/completions`;
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,5 +1,6 @@
 import { runKimi } from "./client.js";
 import type { AiGatewayOptions, GatewayMeta } from "./client.js";
+import type { CustomEndpoint } from "./custom-endpoint.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
 import { sanitizeString, stableStringify, stripOldImages } from "./messages.js";
@@ -117,6 +118,9 @@ export interface AgentTurnOpts {
   providerKeyAliases?: Partial<Record<"workers-ai" | "anthropic" | "openai" | "google" | "moonshotai" | "openai-compatible", string>>;
   /** Whether to use Cloudflare Unified Billing for models that support it. */
   unifiedBilling?: boolean;
+  /** Custom OpenAI-compatible endpoint; when set (or KIMIFLARE_BASE_URL is in
+   *  the env), all Cloudflare routing/auth is bypassed. See src/agent/custom-endpoint.ts. */
+  customEndpoint?: CustomEndpoint;
   /** Shell override for the bash tool. If omitted, the tool auto-detects based on platform. */
   shell?: string;
   /** When false (default), the bash tool blocks `git push` to the default branch. */
@@ -667,6 +671,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       providerKeys: opts.providerKeys,
       providerKeyAliases: opts.providerKeyAliases,
       unifiedBilling: opts.unifiedBilling,
+      customEndpoint: opts.customEndpoint,
       idleTimeoutMs: opts.idleTimeoutMs ?? 60_000,
       postFirstByteIdleTimeoutMs: opts.postFirstByteIdleTimeoutMs,
     });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,7 +1,11 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { validateModelId } from "./agent/client.js";
 import { getModelOrInfer, inferProvider } from "./models/registry.js";
+import { loadConfig } from "./config.js";
 
 describe("validateModelId", () => {
   it("accepts valid Cloudflare Workers AI model IDs", () => {
@@ -47,5 +51,131 @@ describe("model registry", () => {
     assert.equal(m.provider, "anthropic");
     assert.equal(m.billingMode, "byok");
     assert.equal(m.pricing.inputPerMtok, 0); // zero rather than wrong
+  });
+});
+
+describe("loadConfig: custom OpenAI-compatible endpoint", () => {
+  // loadConfig reads env + the config file; isolate both so a developer's
+  // real ~/.config/kimiflare/config.json can't leak into assertions.
+  const ENV_KEYS = [
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CF_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+    "CF_API_TOKEN",
+    "KIMI_MODEL",
+    "KIMIFLARE_CLOUD",
+    "KIMIFLARE_BASE_URL",
+    "KIMIFLARE_API_KEY",
+    "XDG_CONFIG_HOME",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  let configHome: string;
+
+  before(async () => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    configHome = await mkdtemp(join(tmpdir(), "kimiflare-config-test-"));
+    process.env.XDG_CONFIG_HOME = configHome;
+  });
+
+  after(async () => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await rm(configHome, { recursive: true, force: true });
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<void> {
+    const dir = join(configHome, "kimiflare");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "config.json"), JSON.stringify(contents), "utf8");
+  }
+
+  async function removeConfigFile(): Promise<void> {
+    await rm(join(configHome, "kimiflare", "config.json"), { force: true });
+  }
+
+  it("resolves with ONLY KIMIFLARE_BASE_URL + KIMIFLARE_API_KEY set (no Cloudflare credentials anywhere)", async () => {
+    await removeConfigFile();
+    process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "broker-key";
+    try {
+      const cfg = await loadConfig();
+      assert.ok(cfg, "expected a usable config without Cloudflare credentials");
+      assert.strictEqual(cfg!.baseUrl, "https://aig.example.com/v1");
+      assert.strictEqual(cfg!.apiKey, "broker-key");
+      assert.strictEqual(cfg!.accountId, "");
+      assert.strictEqual(cfg!.apiToken, "");
+    } finally {
+      delete process.env.KIMIFLARE_BASE_URL;
+      delete process.env.KIMIFLARE_API_KEY;
+    }
+  });
+
+  it("still returns null with no credentials and no custom endpoint", async () => {
+    await removeConfigFile();
+    assert.strictEqual(await loadConfig(), null);
+  });
+
+  it("resolves a persisted baseUrl/apiKey without Cloudflare credentials", async () => {
+    await writeConfigFile({ baseUrl: "https://cfg.example.com/v1", apiKey: "cfg-key", model: "my-alias" });
+    const cfg = await loadConfig();
+    assert.ok(cfg);
+    assert.strictEqual(cfg!.baseUrl, "https://cfg.example.com/v1");
+    assert.strictEqual(cfg!.apiKey, "cfg-key");
+    assert.strictEqual(cfg!.model, "my-alias");
+  });
+
+  it("env vars win over persisted baseUrl/apiKey", async () => {
+    await writeConfigFile({ baseUrl: "https://cfg.example.com/v1", apiKey: "cfg-key" });
+    process.env.KIMIFLARE_BASE_URL = "https://env.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "env-key";
+    try {
+      const cfg = await loadConfig();
+      assert.ok(cfg);
+      assert.strictEqual(cfg!.baseUrl, "https://env.example.com/v1");
+      assert.strictEqual(cfg!.apiKey, "env-key");
+    } finally {
+      delete process.env.KIMIFLARE_BASE_URL;
+      delete process.env.KIMIFLARE_API_KEY;
+    }
+  });
+
+  it("carries baseUrl/apiKey alongside env Cloudflare credentials (custom endpoint wins at request time)", async () => {
+    await removeConfigFile();
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "cf-token";
+    process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "broker-key";
+    try {
+      const cfg = await loadConfig();
+      assert.ok(cfg);
+      assert.strictEqual(cfg!.accountId, "acct");
+      assert.strictEqual(cfg!.apiToken, "cf-token");
+      assert.strictEqual(cfg!.baseUrl, "https://aig.example.com/v1");
+      assert.strictEqual(cfg!.apiKey, "broker-key");
+    } finally {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      delete process.env.CLOUDFLARE_API_TOKEN;
+      delete process.env.KIMIFLARE_BASE_URL;
+      delete process.env.KIMIFLARE_API_KEY;
+    }
+  });
+
+  it("carries baseUrl/apiKey alongside persisted Cloudflare credentials", async () => {
+    await writeConfigFile({
+      accountId: "acct",
+      apiToken: "cf-token",
+      baseUrl: "https://cfg.example.com/v1",
+      apiKey: "cfg-key",
+    });
+    const cfg = await loadConfig();
+    assert.ok(cfg);
+    assert.strictEqual(cfg!.accountId, "acct");
+    assert.strictEqual(cfg!.baseUrl, "https://cfg.example.com/v1");
+    assert.strictEqual(cfg!.apiKey, "cfg-key");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,22 @@ export interface KimiConfig {
   model: string;
   /** Set when apiToken is an OAuth access token from "Log in with Cloudflare". */
   cloudflareOAuth?: CloudflareOAuthConfig;
+  /**
+   * Custom OpenAI-compatible endpoint base URL (env: KIMIFLARE_BASE_URL).
+   * When set, ALL model calls go to `<baseUrl>/chat/completions` and every
+   * Cloudflare routing/auth path is bypassed: no account-id lookups, no
+   * cf-aig-* headers, no Cloudflare token, and no whoami-style preflights or
+   * OAuth token refresh. Cloudflare credentials become optional. See
+   * src/agent/custom-endpoint.ts.
+   */
+  baseUrl?: string;
+  /**
+   * Bearer sent as `Authorization` to `baseUrl` (env: KIMIFLARE_API_KEY).
+   * Only used when `baseUrl` is set; omitted from the request entirely when
+   * unset (for unauthenticated local gateways). Not a Cloudflare token —
+   * that stays in `apiToken`.
+   */
+  apiKey?: string;
   aiGatewayId?: string;
   aiGatewayCacheTtl?: number;
   aiGatewaySkipCache?: boolean;
@@ -340,6 +356,11 @@ export async function loadConfig(): Promise<KimiConfig | null> {
 
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
+  // Custom OpenAI-compatible endpoint (see src/agent/custom-endpoint.ts).
+  // When a base URL resolves, kimiflare is fully usable without any
+  // Cloudflare credentials — routing and auth belong to the host's gateway.
+  const envBaseUrl = process.env.KIMIFLARE_BASE_URL;
+  const envApiKey = process.env.KIMIFLARE_API_KEY;
   // KIMI_MODEL is an override, not a default: leave it undefined when unset so
   // the persisted `model` (set via /model) is honoured on the next launch.
   const envModel = process.env.KIMI_MODEL || undefined;
@@ -438,6 +459,8 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     return {
       accountId: envAccount,
       apiToken: envToken,
+      baseUrl: envBaseUrl ?? persisted?.baseUrl,
+      apiKey: envApiKey ?? persisted?.apiKey,
       model: envModel ?? DEFAULT_MODEL,
       aiGatewayId: envAiGatewayId,
       aiGatewayCacheTtl: envAiGatewayCacheTtl,
@@ -538,11 +561,13 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     }
     if (parsed.accountId && parsed.apiToken) {
       warnIfBlankGatewayId(parsed.aiGatewayId, "config");
-      return withFreshCloudflareToken({
+      const resolved: KimiConfig = {
         accountId: envAccount ?? parsed.accountId,
         apiToken: envToken ?? parsed.apiToken,
         // An env token overrides the stored OAuth session entirely.
         cloudflareOAuth: envToken ? undefined : parsed.cloudflareOAuth,
+        baseUrl: envBaseUrl ?? parsed.baseUrl,
+        apiKey: envApiKey ?? parsed.apiKey,
         model: envModel ?? parsed.model ?? DEFAULT_MODEL,
         aiGatewayId: envAiGatewayId ?? parsed.aiGatewayId,
         aiGatewayCacheTtl: envAiGatewayCacheTtl ?? parsed.aiGatewayCacheTtl,
@@ -590,8 +615,50 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         workerPreReadMaxChars: envWorkerPreReadMaxChars ?? parsed.workerPreReadMaxChars,
         preferPullRequests: envPreferPullRequests ?? parsed.preferPullRequests ?? true,
         allowDirectPush: envAllowDirectPush ?? parsed.allowDirectPush ?? false,
-      });
+      };
+      // A custom endpoint means no Cloudflare API traffic at all — including
+      // the background OAuth token refresh (the Cloudflare token isn't used
+      // while the custom endpoint is active).
+      return resolved.baseUrl ? resolved : withFreshCloudflareToken(resolved);
     }
+  }
+
+  // Custom OpenAI-compatible endpoint without Cloudflare credentials:
+  // KIMIFLARE_BASE_URL (+ optional KIMIFLARE_API_KEY) is a complete setup on
+  // its own. The host's gateway owns routing and auth, so the Cloudflare
+  // fields stay empty and nothing ever calls a Cloudflare API.
+  const customBaseUrl = envBaseUrl ?? persisted?.baseUrl;
+  if (customBaseUrl) {
+    return {
+      accountId: envAccount ?? persisted?.accountId ?? "",
+      apiToken: envToken ?? persisted?.apiToken ?? "",
+      baseUrl: customBaseUrl,
+      apiKey: envApiKey ?? persisted?.apiKey,
+      model: envModel ?? persisted?.model ?? DEFAULT_MODEL,
+      reasoningEffort: envEffort ?? persisted?.reasoningEffort,
+      coauthor: envCoauthor?.enabled ?? persisted?.coauthor ?? true,
+      coauthorName: envCoauthor?.name ?? persisted?.coauthorName,
+      coauthorEmail: envCoauthor?.email ?? persisted?.coauthorEmail,
+      mcpServers: persisted?.mcpServers,
+      cacheStablePrompts: persisted?.cacheStablePrompts ?? cacheStablePrompts,
+      compiledContext: persisted?.compiledContext ?? compiledContext,
+      imageHistoryTurns: Number.isNaN(imageHistoryTurns) ? persisted?.imageHistoryTurns : imageHistoryTurns,
+      memoryEnabled: envMemoryEnabled ?? persisted?.memoryEnabled ?? false,
+      memoryDbPath: envMemoryDbPath ?? persisted?.memoryDbPath,
+      memoryMaxAgeDays: envMemoryMaxAgeDays ?? persisted?.memoryMaxAgeDays,
+      memoryMaxEntries: envMemoryMaxEntries ?? persisted?.memoryMaxEntries,
+      memoryEmbeddingModel: envMemoryEmbeddingModel ?? persisted?.memoryEmbeddingModel,
+      plumbingModel: envPlumbingModel ?? persisted?.plumbingModel,
+      memoryExtractionModel: envMemoryExtractionModel ?? persisted?.memoryExtractionModel,
+      codeMode: envCodeMode ?? persisted?.codeMode ?? true,
+      costAttribution: envCostAttribution ?? persisted?.costAttribution ?? true,
+      filePicker: envFilePicker ?? persisted?.filePicker ?? true,
+      shell: envShell ?? persisted?.shell,
+      theme: persisted?.theme,
+      uiEngine: persisted?.uiEngine,
+      preferPullRequests: envPreferPullRequests ?? persisted?.preferPullRequests ?? true,
+      allowDirectPush: envAllowDirectPush ?? persisted?.allowDirectPush ?? false,
+    };
   }
   return null;
 }

--- a/src/sdk/config.test.ts
+++ b/src/sdk/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveSdkConfig } from "./config.js";
+
+describe("resolveSdkConfig: custom endpoint credentials", () => {
+  // Isolate env + config file so a developer's real Cloudflare login can't
+  // satisfy the credential check for us.
+  const ENV_KEYS = [
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CF_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+    "CF_API_TOKEN",
+    "KIMIFLARE_CLOUD",
+    "KIMIFLARE_BASE_URL",
+    "KIMIFLARE_API_KEY",
+    "XDG_CONFIG_HOME",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  let configHome: string;
+
+  before(async () => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    configHome = await mkdtemp(join(tmpdir(), "kimiflare-sdk-config-test-"));
+    process.env.XDG_CONFIG_HOME = configHome;
+  });
+
+  after(async () => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await rm(configHome, { recursive: true, force: true });
+  });
+
+  it("throws without Cloudflare credentials and without a custom endpoint", async () => {
+    await assert.rejects(() => resolveSdkConfig({}), /missing credentials/);
+  });
+
+  it("accepts a custom endpoint passed via config instead of Cloudflare credentials", async () => {
+    const cfg = await resolveSdkConfig({
+      config: { baseUrl: "https://aig.example.com/v1", apiKey: "broker-key" },
+    });
+    assert.strictEqual(cfg.baseUrl, "https://aig.example.com/v1");
+    assert.strictEqual(cfg.apiKey, "broker-key");
+    assert.strictEqual(cfg.accountId, "");
+    assert.strictEqual(cfg.apiToken, "");
+  });
+
+  it("accepts KIMIFLARE_BASE_URL + KIMIFLARE_API_KEY from the environment alone", async () => {
+    process.env.KIMIFLARE_BASE_URL = "https://env.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "env-key";
+    try {
+      const cfg = await resolveSdkConfig({});
+      assert.strictEqual(cfg.baseUrl, "https://env.example.com/v1");
+      assert.strictEqual(cfg.apiKey, "env-key");
+    } finally {
+      delete process.env.KIMIFLARE_BASE_URL;
+      delete process.env.KIMIFLARE_API_KEY;
+    }
+  });
+});

--- a/src/sdk/config.ts
+++ b/src/sdk/config.ts
@@ -1,4 +1,5 @@
 import { loadConfig, saveConfig, DEFAULT_MODEL, DEFAULT_REASONING_EFFORT, type KimiConfig } from "../config.js";
+import { resolveCustomEndpoint } from "../agent/custom-endpoint.js";
 import type { CreateSessionOptions } from "./types.js";
 
 export { loadConfig, saveConfig, DEFAULT_MODEL, DEFAULT_REASONING_EFFORT };
@@ -14,9 +15,13 @@ export async function resolveSdkConfig(opts: CreateSessionOptions): Promise<Kimi
     ...opts.config,
   };
 
-  if (!merged.accountId || !merged.apiToken) {
+  // Cloudflare credentials are only required when no custom OpenAI-compatible
+  // endpoint is configured (KIMIFLARE_BASE_URL / config baseUrl) — with one,
+  // the host's gateway owns routing and auth and no Cloudflare API is called.
+  if ((!merged.accountId || !merged.apiToken) && !resolveCustomEndpoint(merged)) {
     throw new Error(
       "kimiflare SDK: missing credentials. Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, " +
+        "set KIMIFLARE_BASE_URL (+ KIMIFLARE_API_KEY) for a custom OpenAI-compatible endpoint, " +
         "or provide them in config.",
     );
   }

--- a/src/sdk/rpc.test.ts
+++ b/src/sdk/rpc.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Readable, Writable } from "node:stream";
 import { startRpcServer } from "./rpc.js";
 import type { createAgentSession } from "./session.js";
@@ -108,6 +111,38 @@ function makeFakeSession(behavior: {
   return { session, state };
 }
 
+async function withRpcServer(
+  commands: string[],
+  handler: (lines: string[]) => void,
+  createSession?: SessionFactory,
+): Promise<void> {
+  const allCommands = [...commands, JSON.stringify({ type: "dispose" })];
+  const input = Readable.from(allCommands.map((c) => c + "\n"));
+  const outputLines: string[] = [];
+  const output = new Writable({
+    write(chunk, _encoding, callback) {
+      outputLines.push(chunk.toString().trim());
+      callback();
+    },
+  });
+
+  // Start RPC server; it will process all commands and exit on dispose
+  await startRpcServer(input, output, createSession);
+
+  // Filter out the dispose ok response
+  const filtered = outputLines.filter((l) => {
+    try {
+      const parsed = JSON.parse(l);
+      // Remove only the dispose ok response (no id, type ok)
+      return !(parsed.type === "ok" && parsed.id === undefined);
+    } catch {
+      return true;
+    }
+  });
+
+  handler(filtered);
+}
+
 describe("SDK RPC", () => {
   let originalAccount: string | undefined;
   let originalToken: string | undefined;
@@ -123,38 +158,6 @@ describe("SDK RPC", () => {
     process.env.CLOUDFLARE_ACCOUNT_ID = originalAccount;
     process.env.CLOUDFLARE_API_TOKEN = originalToken;
   });
-
-  async function withRpcServer(
-    commands: string[],
-    handler: (lines: string[]) => void,
-    createSession?: SessionFactory,
-  ): Promise<void> {
-    const allCommands = [...commands, JSON.stringify({ type: "dispose" })];
-    const input = Readable.from(allCommands.map((c) => c + "\n"));
-    const outputLines: string[] = [];
-    const output = new Writable({
-      write(chunk, _encoding, callback) {
-        outputLines.push(chunk.toString().trim());
-        callback();
-      },
-    });
-
-    // Start RPC server; it will process all commands and exit on dispose
-    await startRpcServer(input, output, createSession);
-
-    // Filter out the dispose ok response
-    const filtered = outputLines.filter((l) => {
-      try {
-        const parsed = JSON.parse(l);
-        // Remove only the dispose ok response (no id, type ok)
-        return !(parsed.type === "ok" && parsed.id === undefined);
-      } catch {
-        return true;
-      }
-    });
-
-    handler(filtered);
-  }
 
   it("responds to new_session command", async () => {
     await withRpcServer(
@@ -335,5 +338,84 @@ describe("SDK RPC", () => {
       },
       factory,
     );
+  });
+});
+
+describe("SDK RPC with a custom endpoint only (no Cloudflare credentials)", () => {
+  // Acceptance path for host apps: a container gets KIMIFLARE_BASE_URL +
+  // KIMIFLARE_API_KEY pointed at the host's gateway/broker and nothing else —
+  // no Cloudflare login, token, or account id. RPC mode must come up fully.
+  // Uses the REAL createAgentSession factory so resolveSdkConfig/loadConfig
+  // run for real; env + config file are isolated so a developer's own
+  // Cloudflare login can't satisfy the credential check.
+  const ENV_KEYS = [
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CF_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+    "CF_API_TOKEN",
+    "KIMIFLARE_CLOUD",
+    "KIMIFLARE_BASE_URL",
+    "KIMIFLARE_API_KEY",
+    "XDG_CONFIG_HOME",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  let configHome: string;
+
+  before(async () => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    configHome = await mkdtemp(join(tmpdir(), "kimiflare-rpc-custom-endpoint-"));
+    process.env.XDG_CONFIG_HOME = configHome;
+    process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+    process.env.KIMIFLARE_API_KEY = "broker-key";
+  });
+
+  after(async () => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await rm(configHome, { recursive: true, force: true });
+  });
+
+  it("new_session succeeds with only KIMIFLARE_BASE_URL + KIMIFLARE_API_KEY", async () => {
+    await withRpcServer(
+      [
+        JSON.stringify({ id: "1", type: "new_session" }),
+        JSON.stringify({ id: "2", type: "get_state" }),
+      ],
+      (lines) => {
+        const parsed = lines.map((l) => JSON.parse(l));
+        const newSession = parsed.find((r) => r.id === "1");
+        assert.ok(newSession, "new_session got no response");
+        assert.strictEqual(newSession.type, "ok");
+        assert.ok(newSession.sessionId);
+        const state = parsed.find((r) => r.id === "2");
+        assert.ok(state, "get_state got no response");
+        assert.strictEqual(state.type, "state");
+        assert.strictEqual(typeof state.isStreaming, "boolean");
+      },
+    );
+  });
+
+  it("new_session still fails without the custom endpoint vars (missing credentials)", async () => {
+    delete process.env.KIMIFLARE_BASE_URL;
+    delete process.env.KIMIFLARE_API_KEY;
+    try {
+      await withRpcServer(
+        [JSON.stringify({ id: "1", type: "new_session" })],
+        (lines) => {
+          const response = lines.map((l) => JSON.parse(l)).find((r) => r.id === "1");
+          assert.ok(response);
+          assert.strictEqual(response.type, "error");
+          assert.match(response.error, /missing credentials/);
+        },
+      );
+    } finally {
+      process.env.KIMIFLARE_BASE_URL = "https://aig.example.com/v1";
+      process.env.KIMIFLARE_API_KEY = "broker-key";
+    }
   });
 });

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -16,6 +16,7 @@ import { saveSession, loadSession, makeSessionId, sessionsDir } from "../session
 import type { SessionFile } from "../sessions.js";
 import { recordUsage } from "../usage-tracker.js";
 import type { GatewayMeta } from "../agent/client.js";
+import { resolveCustomEndpoint } from "../agent/custom-endpoint.js";
 import { logger } from "../util/logger.js";
 import { resolveSdkConfig } from "./config.js";
 import type { CreateSessionOptions, KimiFlareSession, SessionEvent, SessionUsage, SessionStatus, PromptOptions } from "./types.js";
@@ -525,6 +526,9 @@ class InternalSession implements KimiFlareSession {
     await runAgentTurn({
       accountId: this.config.accountId,
       apiToken: this.config.apiToken,
+      // Custom OpenAI-compatible endpoint (config baseUrl/apiKey or
+      // KIMIFLARE_BASE_URL/KIMIFLARE_API_KEY): overrides all Cloudflare routing.
+      customEndpoint: resolveCustomEndpoint(this.config) ?? undefined,
       model: this.model,
       messages: this.messages,
       tools: this.allTools,
@@ -585,6 +589,8 @@ function gatewayUsageLookup(
   meta: import("../agent/client.js").GatewayMeta,
 ): import("../usage-tracker.js").GatewayUsageLookup | undefined {
   if (!config.aiGatewayId) return undefined;
+  // Custom endpoint active: no Cloudflare account to reconcile against.
+  if (resolveCustomEndpoint(config)) return undefined;
   return {
     accountId: config.accountId,
     apiToken: config.apiToken,


### PR DESCRIPTION
## What

Two new settings that route ALL model calls through a custom OpenAI-compatible endpoint:

- `KIMIFLARE_BASE_URL` (env, or `baseUrl` in config): an OpenAI-compatible base; `/chat/completions` is appended (not doubled). When set, it takes precedence over every Cloudflare path: cloud mode, AI Gateway Universal Endpoint, cf-catalog, direct Workers AI, BYOK/unified billing.
- `KIMIFLARE_API_KEY` (env, or `apiKey` in config): sent as `Authorization: Bearer ...`; omitted entirely when unset (local unauthenticated gateways).

When a custom endpoint is active: no `cf-aig-*` headers, no account-id URLs, no Cloudflare token fallback or OAuth refresh, no gateway-log usage reconciliation, no cloud usage reporting. Model ids pass through verbatim. Precedence is env > config, per field (the repo's standard rule).

## Why

Hosts embedding KimiFlare headless (Agents, agents.insertcompanywebsite.com) broker model traffic through their own worker (`/aig`) so containers never hold a raw Cloudflare token. This makes KimiFlare pointable at such a broker with two env vars and zero Cloudflare credentials in the container.

## Acceptance (ran live)

`tsx src/index.tsx --mode rpc` with ONLY the two env vars set (CF vars scrubbed, empty XDG_CONFIG_HOME): `new_session`/`get_state` work, and a full prompt turn against a local fake broker received `POST /v1/chat/completions` with `Authorization: Bearer broker-key`, zero `cf-aig-*` headers, and the model id verbatim, with the streamed reply forwarded over RPC.

## Tests

850 total, 847 pass; the 3 failures (supervisor prototype, status gateway cache, theme contrast) fail identically on clean origin/main. New suites: custom-endpoint resolution/precedence, header construction, RPC startup without Cloudflare creds.

## Review order

1. `src/agent/custom-endpoint.ts` (the whole contract in one screen)
2. `src/agent/client.ts` (`runKimi`/`buildKimiRequestTarget` routing)
3. `src/config.ts` (resolution, refresh skip, credential-free branch)
4. `src/sdk/config.ts`, `src/sdk/session.ts`, `src/agent/loop.ts` (RPC threading)
5. Tests + README "Custom gateway endpoint" section

Design note: config-file values thread explicitly through the SDK turn path while `runKimi` also env-falls-back internally, so `KIMIFLARE_BASE_URL` reroutes every call site (summarization, memory extraction, ...). Memory embeddings and `/cost` reconciliation remain Cloudflare-only (documented; memory is off by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)